### PR TITLE
Delete init position override, add fullscreen toggle

### DIFF
--- a/Photino.Native/Photino.Mac.mm
+++ b/Photino.Native/Photino.Mac.mm
@@ -37,15 +37,19 @@ void Photino::Register()
 Photino::Photino(AutoString title, Photino* parent, WebMessageReceivedCallback webMessageReceivedCallback, bool fullscreen, int x, int y, int width, int height)
 {
     _webMessageReceivedCallback = webMessageReceivedCallback;
+    
+    // Create Window
     NSRect frame = NSMakeRect(x, y, width, height);
     NSWindow *window = [[NSWindow alloc]
         initWithContentRect:frame
         styleMask:NSWindowStyleMaskTitled | NSWindowStyleMaskClosable | NSWindowStyleMaskResizable | NSWindowStyleMaskMiniaturizable
         backing: NSBackingStoreBuffered
         defer: false];
+    
+    [window fullscreen:bool(fullscreen)];
+    
     _window = window;
 
-    [window cascadeTopLeftFromPoint:NSMakePoint(20,20)];
     SetTitle(title);
 
     WKWebViewConfiguration *webViewConfiguration = [[WKWebViewConfiguration alloc] init];


### PR DESCRIPTION
When trying to initialize a macOS Photino window, the fullscreen and initial position arguments are not considered in the Native init code.

To fix this, I removed the **cascadeFromTopLeft** command that overwrote the position with (20, 20) and added a call to the window fullscreen method to toggle fullscreen from the fullscreen argument.