### PR TITLE
Fix pixelated window and task bar icon

### DIFF
--- a/Photino.Native/Photino.Windows.cpp
+++ b/Photino.Native/Photino.Windows.cpp
@@ -496,9 +496,12 @@ void Photino::SetTopmost(bool topmost)
 
 void Photino::SetIconFile(AutoString filename)
 {
-	HICON icon = (HICON)LoadImage(NULL, filename, IMAGE_ICON, 0, 0, LR_LOADFROMFILE);
-	if (icon)
+	HICON iconSmall = (HICON)LoadImage(NULL, filename, IMAGE_ICON, 16, 16, LR_LOADFROMFILE | LR_LOADTRANSPARENT);
+	HICON iconBig = (HICON)LoadImage(NULL, filename, IMAGE_ICON, 32, 32, LR_LOADFROMFILE | LR_LOADTRANSPARENT);
+
+	if (iconSmall && iconBig)
 	{
-		SendMessage(_hWnd, WM_SETICON, ICON_SMALL, (LPARAM)icon);
+		SendMessage(_hWnd, WM_SETICON, ICON_SMALL, (LPARAM)iconSmall);
+		SendMessage(_hWnd, WM_SETICON, ICON_BIG, (LPARAM)iconBig);
 	}
 }


### PR DESCRIPTION
Changes the SetIconFile method such that the icon will no longer appear pixelated on the window or task bar.

Before| After
------------ | -------------
![Before](https://i.imgur.com/l4QdRac.png) |![After](https://i.imgur.com/FUMDoUW.png)