### PR TITLE
Chromeless style for macOS target (still needs dragging support)

### DIFF
--- a/Photino.Native/Photino.Mac.mm
+++ b/Photino.Native/Photino.Mac.mm
@@ -56,12 +56,20 @@ Photino::Photino(
     // Create Window
     NSRect frame = NSMakeRect(0, 0, 0, 0);
 
+    NSWindowStyleMask style;
+    if (chromeless) {
+        style = NSWindowStyleMaskBorderless;
+    }
+    else {
+        style = NSWindowStyleMaskTitled
+              | NSWindowStyleMaskClosable
+              | NSWindowStyleMaskResizable
+              | NSWindowStyleMaskMiniaturizable;
+    }
+
     _window = [[NSWindow alloc]
         initWithContentRect: frame
-        styleMask: NSWindowStyleMaskTitled
-                 | NSWindowStyleMaskClosable
-                 | NSWindowStyleMaskResizable
-                 | NSWindowStyleMaskMiniaturizable
+        styleMask: style
         backing: NSBackingStoreBuffered
         defer: true];
     


### PR DESCRIPTION
Refs #39 

Uses the `chromeless` parameter to decide how the window should be styled. Still needs to support drag regions, but this renders a window without the title bar or traffic light icons.

![image](https://user-images.githubusercontent.com/6320771/115798153-8cabd400-a3a3-11eb-8f4b-d9b0533c2fcd.png)