### PR TITLE
Windows 10 dark mode support

### DIFF
--- a/Photino.Native/Photino.Native.vcxproj
+++ b/Photino.Native/Photino.Native.vcxproj
@@ -157,12 +157,14 @@ COPY .\$(OutDir)WebView2Loader.dll ..\Photino.Test\bin\Debug\net5.0\</Command>
     <ClCompile Include="Exports.cpp" />
     <ClCompile Include="Photino.Linux.cpp" />
     <ClCompile Include="Photino.Windows.cpp" />
+    <ClCompile Include="Photino.Windows.DarkMode.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Photino.h" />
     <ClInclude Include="Photino.Mac.AppDelegate.h" />
     <ClInclude Include="Photino.Mac.UiDelegate.h" />
     <ClInclude Include="Photino.Mac.UrlSchemeHandler.h" />
+    <ClInclude Include="Photino.Windows.DarkMode.h" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/Photino.Native/Photino.Native.vcxproj.filters
+++ b/Photino.Native/Photino.Native.vcxproj.filters
@@ -24,6 +24,9 @@
     <ClCompile Include="Photino.Linux.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="Photino.Windows.DarkMode.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />
@@ -52,6 +55,9 @@
       <Filter>Source Files</Filter>
     </ClInclude>
     <ClInclude Include="Photino.Mac.UrlSchemeHandler.h">
+      <Filter>Source Files</Filter>
+    </ClInclude>
+    <ClInclude Include="Photino.Windows.DarkMode.h">
       <Filter>Source Files</Filter>
     </ClInclude>
   </ItemGroup>

--- a/Photino.Native/Photino.Windows.DarkMode.cpp
+++ b/Photino.Native/Photino.Windows.DarkMode.cpp
@@ -1,0 +1,170 @@
+#include "Photino.Windows.DarkMode.h"
+
+#include <mutex>
+
+using RtlGetNtVersionNumbers_f = void(WINAPI *)(LPDWORD, LPDWORD, LPDWORD);
+
+using SetWindowCompositionAttribute_f =
+    HRESULT(WINAPI *)(HWND, WINDOWCOMPOSITIONATTRIBDATA *);
+
+using ShouldAppsUseDarkMode_f = BOOLEAN(WINAPI *)();
+
+using AllowDarkModeForWindow_f = BOOLEAN(WINAPI *)(HWND, BOOLEAN);
+
+using RefreshImmersiveColorPolicyState_f = void(WINAPI *)();
+
+using IsDarkModeAllowedForWindow_f = BOOLEAN(WINAPI *)(HWND);
+
+using GetIsImmersiveColorUsingHighContrast_f =
+    BOOLEAN(WINAPI *)(IMMERSIVE_HC_CACHE_MODE);
+
+using SetPreferredAppMode_f = PreferredAppMode(WINAPI *)(PreferredAppMode);
+
+static SetWindowCompositionAttribute_f SetWindowCompositionAttribute = nullptr;
+static ShouldAppsUseDarkMode_f ShouldAppsUseDarkMode = nullptr;
+static AllowDarkModeForWindow_f AllowDarkModeForWindow = nullptr;
+static RefreshImmersiveColorPolicyState_f RefreshImmersiveColorPolicyState =
+    nullptr;
+static IsDarkModeAllowedForWindow_f IsDarkModeAllowedForWindow = nullptr;
+static GetIsImmersiveColorUsingHighContrast_f
+    GetIsImmersiveColorUsingHighContrast = nullptr;
+static SetPreferredAppMode_f SetPreferredAppMode = nullptr;
+
+static constexpr DWORD WIN10_MINIMUM_BUILD_DARK_MODE = 18362;
+
+static std::once_flag flag_init_dark_mode_support;
+
+static void EnableDarkModeForApp() noexcept {
+    if (SetPreferredAppMode != nullptr) {
+        SetPreferredAppMode(AllowDark);
+    }
+}
+
+[[nodiscard]] static DWORD GetBuildNumber() noexcept {
+    auto RtlGetNtVersionNumbers =
+        reinterpret_cast<RtlGetNtVersionNumbers_f>(GetProcAddress(
+            GetModuleHandleW(L"ntdll.dll"), "RtlGetNtVersionNumbers"));
+
+    if (RtlGetNtVersionNumbers == nullptr) {
+        return 0;
+    }
+
+    DWORD major = 0;
+    DWORD minor = 0;
+    DWORD build = 0;
+    RtlGetNtVersionNumbers(&major, &minor, &build);
+    build &= ~0xF0000000;
+    return build;
+}
+
+[[nodiscard]] static bool IsHighContrast() noexcept {
+    HIGHCONTRASTW high_contrast;
+    high_contrast.cbSize = sizeof(high_contrast);
+    if (SystemParametersInfoW(SPI_GETHIGHCONTRAST,
+                              sizeof(high_contrast),
+                              &high_contrast,
+                              FALSE) == TRUE) {
+        return (high_contrast.dwFlags & HCF_HIGHCONTRASTON) > 0;
+    }
+    return false;
+}
+
+static void InitDarkModeSupportOnce() noexcept {
+    const auto build_number = GetBuildNumber();
+
+    if (build_number < WIN10_MINIMUM_BUILD_DARK_MODE) {
+        return;
+    }
+
+    HMODULE uxtheme =
+        LoadLibraryExW(L"uxtheme.dll", nullptr, LOAD_LIBRARY_SEARCH_SYSTEM32);
+
+    if (uxtheme == nullptr) {
+        return;
+    }
+
+    RefreshImmersiveColorPolicyState =
+        reinterpret_cast<RefreshImmersiveColorPolicyState_f>(
+            GetProcAddress(uxtheme, MAKEINTRESOURCEA(104)));
+
+    GetIsImmersiveColorUsingHighContrast =
+        reinterpret_cast<GetIsImmersiveColorUsingHighContrast_f>(
+            GetProcAddress(uxtheme, MAKEINTRESOURCEA(106)));
+
+    ShouldAppsUseDarkMode = reinterpret_cast<ShouldAppsUseDarkMode_f>(
+        GetProcAddress(uxtheme, MAKEINTRESOURCEA(132)));
+
+    AllowDarkModeForWindow = reinterpret_cast<AllowDarkModeForWindow_f>(
+        GetProcAddress(uxtheme, MAKEINTRESOURCEA(133)));
+
+    SetPreferredAppMode = reinterpret_cast<SetPreferredAppMode_f>(
+        GetProcAddress(uxtheme, MAKEINTRESOURCEA(135)));
+
+    IsDarkModeAllowedForWindow =
+        reinterpret_cast<IsDarkModeAllowedForWindow_f>(
+            GetProcAddress(uxtheme, MAKEINTRESOURCEA(137)));
+
+    SetWindowCompositionAttribute =
+        reinterpret_cast<SetWindowCompositionAttribute_f>(GetProcAddress(
+            GetModuleHandleW(L"user32.dll"), "SetWindowCompositionAttribute"));
+
+    if (RefreshImmersiveColorPolicyState != nullptr &&
+        ShouldAppsUseDarkMode != nullptr &&
+        AllowDarkModeForWindow != nullptr && SetPreferredAppMode != nullptr &&
+        IsDarkModeAllowedForWindow != nullptr) {
+        EnableDarkModeForApp();
+        RefreshImmersiveColorPolicyState();
+    }
+}
+
+void InitDarkModeSupport() noexcept {
+    std::call_once(flag_init_dark_mode_support, InitDarkModeSupportOnce);
+}
+
+bool IsDarkModeEnabled() noexcept {
+    if (ShouldAppsUseDarkMode == nullptr) {
+        return false;
+    }
+    return (ShouldAppsUseDarkMode() == TRUE) && !IsHighContrast();
+}
+
+void EnableDarkMode(HWND hwnd, bool enable) noexcept {
+    if (AllowDarkModeForWindow == nullptr) {
+        return;
+    }
+    AllowDarkModeForWindow(hwnd, enable ? TRUE : FALSE);
+}
+
+void RefreshNonClientArea(HWND hwnd) noexcept {
+    if (IsDarkModeAllowedForWindow == nullptr ||
+        ShouldAppsUseDarkMode == nullptr) {
+        return;
+    }
+
+    BOOL dark = FALSE;
+    if (IsDarkModeAllowedForWindow(hwnd) == TRUE &&
+        ShouldAppsUseDarkMode() == TRUE && !IsHighContrast()) {
+        dark = TRUE;
+    }
+
+    if (SetWindowCompositionAttribute != nullptr) {
+        WINDOWCOMPOSITIONATTRIBDATA data = {
+            WCA_USEDARKMODECOLORS, &dark, sizeof(dark)};
+        SetWindowCompositionAttribute(hwnd, &data);
+    }
+}
+
+bool IsColorSchemeChange(LPARAM l_param) noexcept {
+    bool return_value = false;
+    if (l_param > 0 && CompareStringOrdinal(reinterpret_cast<LPCWCH>(l_param),
+                                            -1,
+                                            L"ImmersiveColorSet",
+                                            -1,
+                                            TRUE) == CSTR_EQUAL) {
+        RefreshImmersiveColorPolicyState();
+        return_value = true;
+    }
+
+    GetIsImmersiveColorUsingHighContrast(IHCM_REFRESH);
+    return return_value;
+}

--- a/Photino.Native/Photino.Windows.DarkMode.h
+++ b/Photino.Native/Photino.Windows.DarkMode.h
@@ -1,0 +1,59 @@
+#pragma once
+
+#include <Windows.h>
+
+void InitDarkModeSupport() noexcept;
+[[nodiscard]] bool IsDarkModeEnabled() noexcept;
+void EnableDarkMode(HWND hwnd, bool enable) noexcept;
+void RefreshNonClientArea(HWND hwnd) noexcept;
+[[nodiscard]] bool IsColorSchemeChange(LPARAM l_param) noexcept;
+
+enum IMMERSIVE_HC_CACHE_MODE {
+    IHCM_USE_CACHED_VALUE = 0,
+    IHCM_REFRESH = 1,
+};
+
+enum PreferredAppMode {
+    Default = 0,
+    AllowDark = 1,
+    ForceDark = 2,
+    ForceLight = 3,
+    Max = 4,
+};
+
+enum WINDOWCOMPOSITIONATTRIB {
+    WCA_UNDEFINED = 0,
+    WCA_NCRENDERING_ENABLED = 1,
+    WCA_NCRENDERING_POLICY = 2,
+    WCA_TRANSITIONS_FORCEDISABLED = 3,
+    WCA_ALLOW_NCPAINT = 4,
+    WCA_CAPTION_BUTTON_BOUNDS = 5,
+    WCA_NONCLIENT_RTL_LAYOUT = 6,
+    WCA_FORCE_ICONIC_REPRESENTATION = 7,
+    WCA_EXTENDED_FRAME_BOUNDS = 8,
+    WCA_HAS_ICONIC_BITMAP = 9,
+    WCA_THEME_ATTRIBUTES = 10,
+    WCA_NCRENDERING_EXILED = 11,
+    WCA_NCADORNMENTINFO = 12,
+    WCA_EXCLUDED_FROM_LIVEPREVIEW = 13,
+    WCA_VIDEO_OVERLAY_ACTIVE = 14,
+    WCA_FORCE_ACTIVEWINDOW_APPEARANCE = 15,
+    WCA_DISALLOW_PEEK = 16,
+    WCA_CLOAK = 17,
+    WCA_CLOAKED = 18,
+    WCA_ACCENT_POLICY = 19,
+    WCA_FREEZE_REPRESENTATION = 20,
+    WCA_EVER_UNCLOAKED = 21,
+    WCA_VISUAL_OWNER = 22,
+    WCA_HOLOGRAPHIC = 23,
+    WCA_EXCLUDED_FROM_DDA = 24,
+    WCA_PASSIVEUPDATEMODE = 25,
+    WCA_USEDARKMODECOLORS = 26,
+    WCA_LAST = 27,
+};
+
+struct WINDOWCOMPOSITIONATTRIBDATA {
+    WINDOWCOMPOSITIONATTRIB Attrib;
+    PVOID pvData;
+    SIZE_T cbData;
+};


### PR DESCRIPTION
Enable Windows 10's dark mode titlebar. It will also switch from dark to light and vice-versa as the option is changed in Windows' settings.


![example](https://i.imgur.com/W73v0Ve.png)
