### PR TITLE
Add libnotify-dev as dependency for building on LInux

### DIFF
--- a/makefile
+++ b/makefile
@@ -51,7 +51,7 @@ build-photino-mac-dev:
 
 install-linux-dependencies:
 	sudo apt-get update\
-	&& sudo apt-get install libgtk-3-dev libwebkit2gtk-4.0-dev
+	&& sudo apt-get install libgtk-3-dev libwebkit2gtk-4.0-dev libnotify-dev
 
 build-photino-linux:
 	# "build-photino-linux is not defined"


### PR DESCRIPTION
Fixes the following error when building on LInux:

```
c++ -o ./lib/dev/Photino.Native.so\
	  -std=c++2a -Wall -O2 -shared -fPIC\
	  ./Photino.Native/Photino.Linux.cpp\
	  ./Photino.Native/Exports.cpp\
	  `pkg-config --cflags --libs gtk+-3.0 webkit2gtk-4.0`
./Photino.Native/Photino.Linux.cpp:12:10: fatal error: libnotify/notify.h: No such file or directory
   12 | #include <libnotify/notify.h>
      |          ^~~~~~~~~~~~~~~~~~~~
```