### PR TITLE
win7 support

### DIFF
--- a/Photino.Native/Photino.Native.vcxproj
+++ b/Photino.Native/Photino.Native.vcxproj
@@ -159,6 +159,7 @@ COPY .\$(OutDir)WebView2Loader.dll ..\Photino.Test\bin\Debug\net5.0\</Command>
     <ClCompile Include="Photino.Linux.cpp" />
     <ClCompile Include="Photino.Windows.cpp" />
     <ClCompile Include="Photino.Windows.DarkMode.cpp" />
+    <ClCompile Include="Photino.Windows.DpiHelp.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Dependencies\wintoastlib.h" />
@@ -168,6 +169,7 @@ COPY .\$(OutDir)WebView2Loader.dll ..\Photino.Test\bin\Debug\net5.0\</Command>
     <ClInclude Include="Photino.Mac.UrlSchemeHandler.h" />
     <ClInclude Include="Photino.Windows.ToastHandler.h" />
     <ClInclude Include="Photino.Windows.DarkMode.h" />
+    <ClInclude Include="Photino.Windows.DpiHelp.h" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/Photino.Native/Photino.Native.vcxproj.filters
+++ b/Photino.Native/Photino.Native.vcxproj.filters
@@ -30,6 +30,9 @@
     <ClCompile Include="Photino.Windows.DarkMode.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="Photino.Windows.DpiHelp.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />
@@ -68,6 +71,9 @@
     </ClInclude>
     <ClInclude Include="Photino.Windows.DarkMode.h">
       <Filter>Source Files</Filter>
+    </ClInclude>
+    <ClInclude Include="Photino.Windows.DpiHelp.h">
+      <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>
 </Project>

--- a/Photino.Native/Photino.Windows.DpiHelp.cpp
+++ b/Photino.Native/Photino.Windows.DpiHelp.cpp
@@ -1,0 +1,124 @@
+#include "Photino.Windows.DpiHelp.h"
+
+// =============================================
+//
+// Types
+//
+// ===================
+typedef UINT(WINAPI *_GetDpiForWindowFunc)(HWND hwnd);
+typedef DPI_AWARENESS_CONTEXT(WINAPI *_SetThreadDpiAwarenessContextFunc)(DPI_AWARENESS_CONTEXT dpiContext);
+typedef int(WINAPI *_GetSystemMetricsForDpiFunc)(int nIndex, UINT dpi);
+
+// =============================================
+//
+// Forward declarations
+//
+// ===================
+UINT FallbackGetDpiForWindow(HWND hwnd);
+DPI_AWARENESS_CONTEXT FallbackSetThreadDpiAwarenessContext(DPI_AWARENESS_CONTEXT dpiContext);
+int FallbackGetSystemMetricsForDpiFunc(int nIndex, UINT dpi);
+
+// =============================================
+//
+// Statics
+//
+// ===================
+static HMODULE s_user32 = nullptr;
+
+static _GetDpiForWindowFunc _getDpiForWindow = FallbackGetDpiForWindow;
+static _GetSystemMetricsForDpiFunc _getSystemMetricsForDpi = FallbackGetSystemMetricsForDpiFunc;
+static _SetThreadDpiAwarenessContextFunc _setThreadDpiAwarenessContext = FallbackSetThreadDpiAwarenessContext;
+
+// =============================================
+//
+// Helpers
+//
+// ===================
+static UINT FallbackGetDpiForWindow(HWND hwnd)
+{
+	return 96;
+}
+
+static DPI_AWARENESS_CONTEXT FallbackSetThreadDpiAwarenessContext(DPI_AWARENESS_CONTEXT dpiContext)
+{
+	return nullptr;
+}
+
+static int FallbackGetSystemMetricsForDpiFunc(int nIndex, UINT dpi)
+{
+	return GetSystemMetrics(nIndex);
+}
+
+static void SetFallbacks()
+{
+	_getDpiForWindow = FallbackGetDpiForWindow;
+	_getSystemMetricsForDpi = FallbackGetSystemMetricsForDpiFunc;
+	_setThreadDpiAwarenessContext = FallbackSetThreadDpiAwarenessContext;
+}
+
+// =============================================	
+//
+// Exports
+//
+// ===================
+void CloseDpiHelper()
+{
+	SetFallbacks();
+
+	if (s_user32 != nullptr)
+	{
+		FreeLibrary(s_user32);
+		s_user32 = nullptr;
+	}
+}
+
+int GetScreenHeight(int dpi)
+{
+	return _getSystemMetricsForDpi(SM_CYSCREEN, dpi);
+}
+
+int GetScreenWidth(int dpi)
+{
+	return _getSystemMetricsForDpi(SM_CXSCREEN, dpi);
+}
+
+unsigned int GetWindowDpi(HWND hwnd)
+{
+	return _getDpiForWindow(hwnd);
+}
+
+void InitDpiHelper()
+{
+	SetFallbacks();
+	
+	s_user32 = LoadLibrary(L"User32.dll");
+	if (s_user32 == nullptr)
+	{
+		return;
+	}
+
+	auto win10GetDpiForWindow = (_GetDpiForWindowFunc)GetProcAddress(s_user32, "GetDpiForWindow");
+	if (win10GetDpiForWindow != nullptr)
+	{
+		_getDpiForWindow = win10GetDpiForWindow;
+	}
+
+	auto win10GetSystemMetricsForDpi = (_GetSystemMetricsForDpiFunc)GetProcAddress(s_user32, "GetSystemMetricsForDpi");
+	if (win10GetSystemMetricsForDpi != nullptr)
+	{
+		_getSystemMetricsForDpi = win10GetSystemMetricsForDpi;
+	}
+
+	auto win10SetThreadDpiAwarenessContext = (_SetThreadDpiAwarenessContextFunc)GetProcAddress(s_user32, "SetThreadDpiAwarenessContext");
+	if (win10SetThreadDpiAwarenessContext != nullptr)
+	{
+		auto oldVal = win10SetThreadDpiAwarenessContext(DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE);
+		if (oldVal == nullptr)
+		{
+			CloseDpiHelper(); // failed init of the win10+ apis
+			return;
+		}
+
+		_setThreadDpiAwarenessContext = win10SetThreadDpiAwarenessContext;
+	}
+}

--- a/Photino.Native/Photino.Windows.DpiHelp.h
+++ b/Photino.Native/Photino.Windows.DpiHelp.h
@@ -1,0 +1,9 @@
+#pragma once
+
+#include <Windows.h>
+
+void CloseDpiHelper();
+int GetScreenHeight(int dpi);
+int GetScreenWidth(int dpi);
+unsigned int GetWindowDpi(HWND hwnd);
+void InitDpiHelper();

--- a/Photino.Native/Photino.Windows.cpp
+++ b/Photino.Native/Photino.Windows.cpp
@@ -10,6 +10,10 @@
 
 #include "Photino.Windows.DarkMode.h"
 
+#ifdef COMPAT_DPI
+#include "Photino.Windows.DpiHelp.h"
+#endif
+
 #pragma comment(lib, "Urlmon.lib")
 #pragma warning(disable: 4996)		//disable warning about wcscpy vs. wcscpy_s
 
@@ -65,7 +69,11 @@ void Photino::Register(HINSTANCE hInstance)
 
 	RegisterClassEx(&wcx);
 
+#ifdef COMPAT_DPI
+	InitDpiHelper();
+#else
 	SetThreadDpiAwarenessContext(DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE);
+#endif
 }
 
 
@@ -232,6 +240,10 @@ Photino::Photino(PhotinoInitParams* initParams)
 
 Photino::~Photino()
 {
+#ifdef COMPAT_DPI
+	CloseDpiHelper();
+#endif
+
 	if (_startUrl != NULL) delete[]_startUrl;
 	if (_startString != NULL) delete[]_startString;
 	if (_temporaryFilesPath != NULL) delete[]_temporaryFilesPath;
@@ -370,9 +382,15 @@ LRESULT CALLBACK WindowProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
 
 void Photino::Center()
 {
+#ifdef COMPAT_DPI
+	int screenDpi = GetWindowDpi(_hWnd);
+	int screenHeight = GetScreenHeight(screenDpi);
+	int screenWidth = GetScreenWidth(screenDpi);
+#else
 	int screenDpi = GetDpiForWindow(_hWnd);
 	int screenHeight = GetSystemMetricsForDpi(SM_CYSCREEN, screenDpi);
 	int screenWidth = GetSystemMetricsForDpi(SM_CXSCREEN, screenDpi);
+#endif
 
 	RECT windowRect = {};
 	GetWindowRect(_hWnd, &windowRect);
@@ -454,7 +472,11 @@ void Photino::GetResizable(bool* resizable)
 
 unsigned int Photino::GetScreenDpi()
 {
+#ifdef COMPAT_DPI
+	return GetWindowDpi(_hWnd);
+#else
 	return GetDpiForWindow(_hWnd);
+#endif
 }
 
 void Photino::GetSize(int* width, int* height)

--- a/Photino.Native/Photino.h
+++ b/Photino.Native/Photino.h
@@ -1,6 +1,14 @@
 #pragma once
 
 #ifdef _WIN32
+
+#define COMPAT_DPI
+
+#ifdef COMPAT_DPI
+#define WINVER _WIN32_WINNT_WIN7
+#define _WIN32_WINNT _WIN32_WINNT_WIN7
+#endif
+
 #include <Windows.h>
 #include <wil/com.h>
 #include <WebView2.h>


### PR DESCRIPTION
Both .NET6 and WebView2 provide support for windows versions all the way back to Win7 SP1. Currently, we can't compile for Win7 due to the use of the newer DPI-awareness APIs which are only available in Win10+

This is a proposal to dynamically load those APIs only on platforms that support them, allowing us to run without dpi support on older win7/win8 installations. Some future work could be done to wire up the primitive dpi support that earlier versions of windows did provide, though that is not yet done and tested in this PR.

The proposed changes are enabled by defining `COMPAT_DPI` within the `_WIN32` section of Photino.h. Without `COMPAT_DPI` defined, the previous code structure is maintained as-is.

Thoughts or opinions on this?