### PR TITLE
fix for crash in DarkMode on older platforms

### DIFF
--- a/Photino.Native/Photino.Windows.DarkMode.cpp
+++ b/Photino.Native/Photino.Windows.DarkMode.cpp
@@ -165,6 +165,8 @@ bool IsColorSchemeChange(LPARAM l_param) noexcept {
         return_value = true;
     }
 
-    GetIsImmersiveColorUsingHighContrast(IHCM_REFRESH);
+    if (GetIsImmersiveColorUsingHighContrast != nullptr) {
+        GetIsImmersiveColorUsingHighContrast(IHCM_REFRESH);
+    }
     return return_value;
 }


### PR DESCRIPTION
- IsColorSchemeChange will be called on all platforms, but
  GetIsImmersiveColorUsingHighContrast is dynamically loaded on Win10+
  and not nullchecked before being called. This leads to a null ref crash on Win7
  and 8