### PR TITLE
Fix(Linux): Don't show a dialog on permission request.

### DIFF
--- a/Photino.Native/Photino.Linux.cpp
+++ b/Photino.Native/Photino.Linux.cpp
@@ -750,7 +750,12 @@ gboolean on_webview_context_menu (WebKitWebView* web_view, GtkWidget* default_me
 
 gboolean on_permission_request(WebKitWebView* web_view, WebKitPermissionRequest* request, gpointer user_data)
 {
-	webkit_permission_request_allow(request);
+	if (_grantBrowserPermissions) {
+		webkit_permission_request_allow(request);
+	}
+	else {
+		webkit_permission_request_deny(request);
+	}
 	return FALSE;
 }
 

--- a/Photino.Native/Photino.Linux.cpp
+++ b/Photino.Native/Photino.Linux.cpp
@@ -750,15 +750,6 @@ gboolean on_webview_context_menu (WebKitWebView* web_view, GtkWidget* default_me
 
 gboolean on_permission_request(WebKitWebView* web_view, WebKitPermissionRequest* request, gpointer user_data)
 {
-	GtkWidget* dialog = gtk_message_dialog_new(
-		nullptr
-		, GTK_DIALOG_DESTROY_WITH_PARENT
-		, GTK_MESSAGE_ERROR
-		, GTK_BUTTONS_CLOSE
-		, "Permission Requested - Allowing!");
-	gtk_dialog_run(GTK_DIALOG(dialog));
-	gtk_widget_destroy(dialog);
-
 	webkit_permission_request_allow(request);
 	return FALSE;
 }


### PR DESCRIPTION
Currently apps running on Linux show a messagebox with the message "Permission Requested - Granted" each time the web app requests any permission such as for notifications.

This PR ~~simply~~ removes the dialog.

Edit: This PR now takes account of the GrantBrowserPermissions Photino window setting. It will grant/deny the permission request based on this.