### PR TITLE
Add ability to create directories in macOS open folder dialog

### DIFF
--- a/Photino.Native/Photino.Mac.Dialog.mm
+++ b/Photino.Native/Photino.Mac.Dialog.mm
@@ -70,6 +70,7 @@ AutoString* PhotinoDialog::ShowOpenFolder(AutoString title, AutoString defaultPa
   [openDlg setTitle:[NSString stringWithUTF8String:title]];
   [openDlg setCanChooseFiles:NO];
   [openDlg setCanChooseDirectories:YES];
+  [openDlg setCanCreateDirectories:YES];
   [openDlg setAllowsMultipleSelection:multiSelect];
   [openDlg setPrompt:[NSString stringWithUTF8String:"Open"]];
   [openDlg setDirectoryURL:[NSURL fileURLWithPath:[NSString stringWithUTF8String:defaultPath]]];


### PR DESCRIPTION
I think enabling the 'New Folder' button to the macOS open folder dialog is a sensible default - there is no way to create a new folder from the dialog without this button.

Is it worth extending the dialog configuration to move this to be user defined?

<img width="829" alt="Screenshot 2024-01-08 at 5 40 19 PM" src="https://github.com/tryphotino/photino.Native/assets/88865848/76da7ef1-2a56-4ae8-9ffe-60a8ec4ea31d">
