### PR TITLE
Implementing basic menu support.

### DIFF
--- a/Photino.Native/Exports.cpp
+++ b/Photino.Native/Exports.cpp
@@ -1,5 +1,8 @@
 #include "Photino.Dialog.h"
+#include "Photino.Errors.h"
+#include "Photino.Menu.h"
 #include "Photino.h"
+#include <exception>
 
 #ifdef _WIN32
 #define EXPORTED __declspec(dllexport)
@@ -292,7 +295,232 @@ extern "C"
 		return inst->GetDialog()->ShowMessage(title, text, buttons, icon);
 	}
 
+	//Error
+	EXPORTED void Photino_ClearErrorMessage()
+	{
+		ClearErrorMessage();
+	}
 
+	EXPORTED void Photino_GetErrorMessage(int length, char* buffer)
+	{
+		GetErrorMessage(length, buffer);
+	}
+
+	EXPORTED void Photino_GetErrorMessageLength(int* length)
+	{
+		*length = GetErrorMessageLength();
+	}
+
+	//Menu
+	EXPORTED PhotinoErrorKind Photino_Menu_Create(Menu** menu)
+	{
+		try
+		{
+			*menu = new Menu();
+		}
+		catch (std::exception exception)
+		{
+			SetErrorMessage(exception.what());
+			return PhotinoErrorKind::GenericError;
+		}
+
+		return PhotinoErrorKind::NoError;
+	}
+
+	EXPORTED PhotinoErrorKind Photino_Menu_Destroy(Menu* menu)
+	{
+		try
+		{
+			menuRenderer.Destroy(menu);
+		}
+		catch (std::exception exception)
+		{
+			SetErrorMessage(exception.what());
+			return PhotinoErrorKind::GenericError;
+		}
+
+		return PhotinoErrorKind::NoError;
+	}
+
+	EXPORTED PhotinoErrorKind Photino_Menu_AddMenuItem(Menu* menu, MenuItem* menuItem)
+	{
+		try
+		{
+			menu->Add(menuItem);
+		}
+		catch (std::exception exception)
+		{
+			SetErrorMessage(exception.what());
+			return PhotinoErrorKind::GenericError;
+		}
+
+		return PhotinoErrorKind::NoError;
+	}
+
+	EXPORTED PhotinoErrorKind Photino_Menu_AddMenuSeparator(Menu* menu, MenuSeparator* menuSeparator)
+	{
+		try
+		{
+			menu->Add(menuSeparator);
+		}
+		catch (std::exception exception)
+		{
+			SetErrorMessage(exception.what());
+			return PhotinoErrorKind::GenericError;
+		}
+
+		return PhotinoErrorKind::NoError;
+	}
+
+	EXPORTED PhotinoErrorKind Photino_Menu_AddOnClicked(Menu* menu, OnClickedCallback onClicked)
+	{
+		try
+		{
+			menu->AddOnClicked(onClicked);
+		}
+		catch (std::exception exception)
+		{
+			SetErrorMessage(exception.what());
+			return PhotinoErrorKind::GenericError;
+		}
+
+		return PhotinoErrorKind::NoError;
+	}
+
+	EXPORTED PhotinoErrorKind Photino_Menu_Hide(Menu* menu)
+	{
+		try
+		{
+			menu->Hide();
+		}
+		catch (std::exception exception)
+		{
+			SetErrorMessage(exception.what());
+			return PhotinoErrorKind::GenericError;
+		}
+
+		return PhotinoErrorKind::NoError;
+	}
+
+	EXPORTED PhotinoErrorKind Photino_Menu_RemoveOnClicked(Menu* menu, OnClickedCallback onClicked)
+	{
+		try
+		{
+			menu->RemoveOnClicked(onClicked);
+		}
+		catch (std::exception exception)
+		{
+			SetErrorMessage(exception.what());
+			return PhotinoErrorKind::GenericError;
+		}
+
+		return PhotinoErrorKind::NoError;
+	}
+
+	EXPORTED PhotinoErrorKind Photino_Menu_Show(Menu* menu, Photino* window, int x, int y)
+	{
+		try
+		{
+			menu->Show(window, x, y);
+		}
+		catch (std::exception exception)
+		{
+			SetErrorMessage(exception.what());
+			return PhotinoErrorKind::GenericError;
+		}
+
+		return PhotinoErrorKind::NoError;
+	}
+
+	EXPORTED PhotinoErrorKind Photino_MenuItem_Create(MenuItemOptions options, MenuItem** menuItem)
+	{
+		try
+		{
+			*menuItem = new MenuItem(options);
+		}
+		catch (std::exception exception)
+		{
+			SetErrorMessage(exception.what());
+			return PhotinoErrorKind::GenericError;
+		}
+
+		return PhotinoErrorKind::NoError;
+	}
+
+	EXPORTED PhotinoErrorKind Photino_MenuItem_AddMenuItem(MenuItem* menuItem, MenuItem* newMenuItem)
+	{
+		try
+		{
+			menuItem->Add(newMenuItem);
+		}
+		catch (std::exception exception)
+		{
+			SetErrorMessage(exception.what());
+			return PhotinoErrorKind::GenericError;
+		}
+
+		return PhotinoErrorKind::NoError;
+	}
+
+	EXPORTED PhotinoErrorKind Photino_MenuItem_AddMenuSeparator(MenuItem* menuItem, MenuSeparator* menuSeparator)
+	{
+		try
+		{
+			menuItem->Add(menuSeparator);
+		}
+		catch (std::exception exception)
+		{
+			SetErrorMessage(exception.what());
+			return PhotinoErrorKind::GenericError;
+		}
+
+		return PhotinoErrorKind::NoError;
+	}
+
+	EXPORTED PhotinoErrorKind Photino_MenuItem_Destroy(MenuItem* menuItem)
+	{
+		try
+		{
+			delete menuItem;
+		}
+		catch (std::exception exception)
+		{
+			SetErrorMessage(exception.what());
+			return PhotinoErrorKind::GenericError;
+		}
+
+		return PhotinoErrorKind::NoError;
+	}
+
+	EXPORTED PhotinoErrorKind Photino_MenuSeparator_Create(MenuSeparator** menuSeparator)
+	{
+		try
+		{
+			*menuSeparator = new MenuSeparator();
+		}
+		catch (std::exception exception)
+		{
+			SetErrorMessage(exception.what());
+			return PhotinoErrorKind::GenericError;
+		}
+
+		return PhotinoErrorKind::NoError;
+	}
+
+	EXPORTED PhotinoErrorKind Photino_MenuSeparator_Destroy(MenuSeparator* menuSeparator)
+	{
+		try
+		{
+			delete menuSeparator;
+		}
+		catch (std::exception exception)
+		{
+			SetErrorMessage(exception.what());
+			return PhotinoErrorKind::GenericError;
+		}
+
+		return PhotinoErrorKind::NoError;
+	}
 
 	//Callbacks
 	EXPORTED void Photino_AddCustomSchemeName(Photino* instance, AutoString scheme)

--- a/Photino.Native/Photino.Errors.cpp
+++ b/Photino.Native/Photino.Errors.cpp
@@ -1,0 +1,25 @@
+#include "Photino.Errors.h"
+#include <mutex>
+#include <string>
+
+static thread_local std::string _lastError;
+
+void ClearErrorMessage() noexcept
+{
+	_lastError.clear();
+}
+
+int GetErrorMessageLength() noexcept
+{
+	return _lastError.length();
+}
+
+void GetErrorMessage(int length, char* buffer) noexcept
+{
+	_lastError.copy(buffer, length, 0);
+}
+
+void SetErrorMessage(std::string message) noexcept
+{
+	_lastError = message;
+}

--- a/Photino.Native/Photino.Errors.h
+++ b/Photino.Native/Photino.Errors.h
@@ -1,0 +1,35 @@
+#pragma once
+#include <string>
+
+/// <summary>
+/// The kind of error message that occurred.
+/// </summary>
+enum class PhotinoErrorKind
+{
+	NoError = 0,
+	GenericError
+};
+
+/// <summary>
+/// Clears the last error message to occur.
+/// </summary>
+void ClearErrorMessage() noexcept;
+
+/// <summary>
+/// Gets the length of the message of the last error to occur.
+/// </summary>
+/// <returns>The length of the last error to occur on this thread.</returns>
+int GetErrorMessageLength() noexcept;
+
+/// <summary>
+/// Gets the message of the last error to occur.
+/// </summary>
+/// <param name="length">The length of the buffer.</param>
+/// <param name="buffer">The buffer to which the message should be written.</param>
+void GetErrorMessage(int length, char* buffer) noexcept;
+
+/// <summary>
+/// Sets the message of the last error to occur.
+/// </summary>
+/// <param name="message">The message.</param>
+void SetErrorMessage(std::string message) noexcept;

--- a/Photino.Native/Photino.Linux.Menu.cpp
+++ b/Photino.Native/Photino.Linux.Menu.cpp
@@ -1,0 +1,270 @@
+#include <algorithm>
+#include <memory>
+#include <stdexcept>
+#include "Photino.Linux.Menu.h"
+#include "gdk/gdk.h"
+#include "gtk/gtk.h"
+
+// -------------------------------------------------------------------------------------------------
+// Variables
+// -------------------------------------------------------------------------------------------------
+
+MenuRenderer menuRenderer{};
+
+// -------------------------------------------------------------------------------------------------
+// Utilities
+// -------------------------------------------------------------------------------------------------
+
+GtkMenu* CreateMenu()
+{
+    return GTK_MENU(gtk_menu_new());
+}
+
+GtkMenuItem* CreateMenuItem(const MenuItemOptions& options)
+{
+    auto result = GTK_MENU_ITEM(gtk_menu_item_new());
+    gtk_menu_item_set_label(result, options.Label);
+    gtk_widget_show_all(GTK_WIDGET(result));
+    return result;
+}
+
+GtkSeparatorMenuItem* CreateSeparator()
+{
+    return reinterpret_cast<GtkSeparatorMenuItem*>(gtk_separator_menu_item_new());
+}
+
+void DeleteMenu(GtkMenu* menu)
+{
+    if (menu != nullptr)
+    {
+        gtk_widget_destroy(GTK_WIDGET(menu));
+    }
+}
+
+void DeleteMenuItem(GtkMenuItem* menuItem)
+{
+    if (menuItem != nullptr)
+    {
+        gtk_widget_destroy(GTK_WIDGET(menuItem));
+    }
+}
+
+void DeleteSeparator(GtkSeparatorMenuItem* separator)
+{
+    if (separator != nullptr)
+    {
+        gtk_widget_destroy(GTK_WIDGET(separator));
+    }
+}
+
+// -------------------------------------------------------------------------------------------------
+// Menu
+// -------------------------------------------------------------------------------------------------
+
+Menu::Menu()
+    : MenuNode()
+    , _menu(CreateMenu(), &DeleteMenu)
+{
+}
+
+void Menu::Add(MenuNode* child)
+{
+    MenuNode::Add(child);
+    child->AddTo(_menu.get());
+}
+
+void Menu::AddOnClicked(const OnClickedCallback onClicked)
+{
+    _onClicked.push_back(onClicked);
+}
+
+void Menu::AddTo(GtkMenu* menu)
+{
+    throw std::logic_error("Menu is a top-level container.");
+}
+
+void Menu::Hide() const
+{
+    gtk_menu_popdown(_menu.get());
+}
+
+void Menu::NotifyOnClicked(MenuItem* item)
+{
+    auto copied = _onClicked;
+
+    for (auto& onClicked : copied)
+    {
+        onClicked(item);
+    }
+}
+
+void Menu::RemoveOnClicked(const OnClickedCallback onClicked)
+{
+    auto index = std::find(_onClicked.begin(), _onClicked.end(), onClicked);
+
+    if (index != _onClicked.end())
+    {
+        _onClicked.erase(index);
+    }
+}
+
+void Menu::Show(const Photino* window, const int x, const int y)
+{
+    // NOTE: We create a synthetic event here since, although this function is likely called as a
+    // response to a user action, that action is unavailable to us.
+
+    int screenX;
+    int screenY;
+
+    gtk_widget_translate_coordinates(
+        window->_window,
+        gtk_widget_get_toplevel(window->_window),
+        x,
+        y,
+        &screenX,
+        &screenY);
+
+    GdkEventButton buttonEvent =
+    {
+        GDK_BUTTON_PRESS,
+        gtk_widget_get_window(window->_window),
+        true,
+        static_cast<uint>(g_get_monotonic_time() / 1000),
+        static_cast<double>(x),
+        static_cast<double>(y),
+        nullptr,
+        0,
+        3,
+        nullptr,
+        static_cast<double>(screenX),
+        static_cast<double>(screenY)
+    };
+
+    GdkEvent event;
+    event.button = buttonEvent;
+    event.type = GDK_BUTTON_PRESS;
+
+    GdkRectangle rect
+    {
+        0,
+        0,
+        1,
+        1
+    };
+
+    gtk_widget_translate_coordinates(
+        window->_webview,
+        window->_window,
+        x,
+        y,
+        &rect.x,
+        &rect.y);
+
+    gtk_menu_popup_at_rect(
+        _menu.get(),
+        buttonEvent.window,
+        &rect,
+        GDK_GRAVITY_SOUTH_EAST,
+        GDK_GRAVITY_NORTH_WEST,
+        &event);
+}
+
+// -------------------------------------------------------------------------------------------------
+// MenuNode
+// -------------------------------------------------------------------------------------------------
+
+MenuNode::MenuNode()
+    : parent(nullptr)
+{
+}
+
+void MenuNode::Add(MenuNode* child)
+{
+    child->parent = this;
+    children.push_back(child);
+}
+
+void MenuNode::NotifyOnClicked(MenuItem* item)
+{
+}
+
+// -------------------------------------------------------------------------------------------------
+// MenuItem
+// -------------------------------------------------------------------------------------------------
+
+MenuItem::MenuItem(MenuItemOptions options)
+    : MenuNode()
+    , _menu(nullptr, &DeleteMenu)
+    , _menuItem(CreateMenuItem(options), &DeleteMenuItem)
+    , _label(options.Label)
+{
+    g_signal_connect(
+        _menuItem.get(),
+        "activate",
+        G_CALLBACK(&MenuItem::OnActivated),
+        this);
+}
+
+void MenuItem::Add(MenuNode* child)
+{
+    MenuNode::Add(child);
+
+    if (_menu == nullptr)
+    {
+        g_signal_handlers_disconnect_by_func(
+            _menuItem.get(),
+            reinterpret_cast<void*>(&MenuItem::OnActivated),
+            this);
+
+        _menu = std::unique_ptr<GtkMenu, void(*)(GtkMenu*)>(CreateMenu(), &DeleteMenu);
+        gtk_menu_item_set_submenu(_menuItem.get(), GTK_WIDGET(_menu.get()));
+    }
+
+    child->AddTo(_menu.get());
+}
+
+void MenuItem::AddTo(GtkMenu* menu)
+{
+    gtk_menu_shell_append(GTK_MENU_SHELL(menu), GTK_WIDGET(_menuItem.get()));
+}
+
+void MenuItem::OnActivated(GtkMenuItem* gtkItem, MenuItem* photinoItem)
+{
+    MenuNode* parent = photinoItem;
+
+    while (parent->parent != nullptr)
+    {
+        parent = parent->parent;
+    }
+
+    parent->NotifyOnClicked(photinoItem);
+}
+
+// -------------------------------------------------------------------------------------------------
+// MenuRenderer
+// -------------------------------------------------------------------------------------------------
+
+void MenuRenderer::Destroy(Menu* menu)
+{
+    delete menu;
+}
+
+// -------------------------------------------------------------------------------------------------
+// MenuSeparator
+// -------------------------------------------------------------------------------------------------
+
+MenuSeparator::MenuSeparator()
+    : MenuNode()
+    , _separator(CreateSeparator(), &DeleteSeparator)
+{
+}
+
+void MenuSeparator::Add(MenuNode* child)
+{
+    throw std::logic_error("Cannot add an item to a separator.");
+}
+
+void MenuSeparator::AddTo(GtkMenu* menu)
+{
+    gtk_menu_shell_append(GTK_MENU_SHELL(menu), GTK_WIDGET(_separator.get()));
+}

--- a/Photino.Native/Photino.Linux.Menu.h
+++ b/Photino.Native/Photino.Linux.Menu.h
@@ -1,0 +1,82 @@
+#pragma once
+#include <memory>
+#include <string>
+#include <gtk/gtk.h>
+#include "Photino.h"
+
+class Menu;
+class MenuChild;
+class MenuItem;
+class MenuItemOptions;
+class MenuNode;
+class MenuParent;
+class MenuRenderer;
+class MenuSeparator;
+
+typedef void (*OnClickedCallback)(MenuItem* menuItem);
+
+class MenuNode
+{
+public:
+    std::vector<MenuNode*> children;
+    MenuNode* parent;
+    MenuNode();
+    virtual ~MenuNode() = default;
+    virtual void Add(MenuNode* node);
+    virtual void AddTo(GtkMenu* menu) = 0;
+    virtual void NotifyOnClicked(MenuItem* item);
+};
+
+class Menu final : public MenuNode
+{
+protected:
+    std::unique_ptr<GtkMenu, void(*)(GtkMenu*)> _menu;
+    std::vector<OnClickedCallback> _onClicked;
+public:
+    Menu();
+    void Add(MenuNode* node) override;
+    void AddOnClicked(const OnClickedCallback onClicked);
+    void AddTo(GtkMenu* menu) override;
+    void Hide() const;
+    void NotifyOnClicked(MenuItem* item) override;
+    void RemoveOnClicked(const OnClickedCallback onClicked);
+    void Show(const Photino* window, const int x, const int y);
+};
+
+class MenuItemOptions final
+{
+public:
+	char* Label;
+};
+
+class MenuItem final : public MenuNode
+{
+private:
+    std::unique_ptr<GtkMenu, void(*)(GtkMenu*)> _menu;
+    std::unique_ptr<GtkMenuItem, void(*)(GtkMenuItem*)> _menuItem;
+    std::string _label;
+    static void OnActivated(GtkMenuItem* gtkItem, MenuItem* photinoItem);
+public:
+    MenuItem(MenuItemOptions options);
+    void Add(MenuNode* child) override;
+    void AddTo(GtkMenu* menu) override;
+};
+
+class MenuRenderer final
+{
+private:
+public:
+    void Destroy(Menu* menu);
+};
+
+class MenuSeparator final : public MenuNode
+{
+private:
+    std::unique_ptr<GtkSeparatorMenuItem, void(*)(GtkSeparatorMenuItem*)> _separator;
+public:
+    MenuSeparator();
+    void Add(MenuNode* child) override;
+    void AddTo(GtkMenu* menu) override;
+};
+
+extern MenuRenderer menuRenderer;

--- a/Photino.Native/Photino.Mac.Menu.h
+++ b/Photino.Native/Photino.Mac.Menu.h
@@ -1,0 +1,98 @@
+#pragma once
+#include <AppKit/AppKit.h>
+#include <memory>
+#include <string>
+#include "Photino.h"
+
+class Menu;
+class MenuItem;
+class MenuItemOptions;
+class MenuNode;
+class MenuRenderer;
+class MenuSeparator;
+
+typedef void (*OnClickedCallback)(MenuItem* menuItem);
+
+@interface MenuItemHandler : NSObject
+- (instancetype)initWithCallback:(std::function<void()>) callback;
+- (void)menuItemAction:(id)sender;
+@end
+
+struct MenuItemHandlerDeleter
+{
+    void operator()(MenuItemHandler* handler);
+};
+
+struct NSMenuDeleter
+{
+    void operator()(NSMenu* menu);
+};
+
+struct NSMenuItemDeleter
+{
+    void operator()(NSMenuItem* menuItem);
+};
+
+class MenuNode
+{
+public:
+    std::vector<MenuNode*> children;
+    MenuNode* parent;
+    MenuNode();
+    virtual ~MenuNode() = default;
+    virtual void Add(MenuNode* node);
+    virtual void AddTo(NSMenu* menu) = 0;
+    virtual void NotifyOnClicked(MenuItem* item);
+};
+
+class Menu final : public MenuNode
+{
+protected:
+    std::unique_ptr<NSMenu, NSMenuDeleter> _menu;
+    std::vector<OnClickedCallback> _onClicked;
+public:
+    Menu();
+    void Add(MenuNode* child) override;
+    void AddOnClicked(const OnClickedCallback onClicked);
+    void AddTo(NSMenu* menu) override;
+    void Hide() const;
+    void NotifyOnClicked(MenuItem* item) override;
+    void RemoveOnClicked(const OnClickedCallback onClicked);
+    void Show(const Photino* window, const int x, const int y) const;
+};
+
+struct MenuItemOptions final
+{
+	char* Label;
+};
+
+class MenuItem final : public MenuNode
+{
+private:
+    std::unique_ptr<NSMenu, NSMenuDeleter> _menu;
+    std::unique_ptr<NSMenuItem, NSMenuItemDeleter> _menuItem;
+    std::unique_ptr<MenuItemHandler, MenuItemHandlerDeleter> _menuItemHandler;
+public:
+    MenuItem(MenuItemOptions options);
+    void Add(MenuNode* child) override;
+    void AddTo(NSMenu* menu) override;
+    void NotifyOnClicked(MenuItem* item) override;
+};
+
+class MenuSeparator final : public MenuNode
+{
+private:
+    std::unique_ptr<NSMenuItem, NSMenuItemDeleter> _menuItem;
+public:
+    MenuSeparator();
+    void Add(MenuNode* child) override;
+    void AddTo(NSMenu* menu) override;
+};
+
+class MenuRenderer final
+{
+public:
+    void Destroy(Menu* menu);
+};
+
+extern MenuRenderer menuRenderer;

--- a/Photino.Native/Photino.Mac.Menu.mm
+++ b/Photino.Native/Photino.Mac.Menu.mm
@@ -1,0 +1,250 @@
+#include <CoreFoundation/CoreFoundation.h>
+#include <Foundation/Foundation.h>
+#include <MacTypes.h>
+#include <memory>
+#include <objc/NSObject.h>
+#include <stdexcept>
+#include "Photino.Mac.Menu.h"
+
+// -------------------------------------------------------------------------------------------------
+// Variables
+// -------------------------------------------------------------------------------------------------
+
+MenuRenderer menuRenderer{};
+
+// -------------------------------------------------------------------------------------------------
+// Utilities
+// -------------------------------------------------------------------------------------------------
+
+std::unique_ptr<MenuItemHandler, MenuItemHandlerDeleter> CreateMenuItemHandler(MenuItem* menuItem)
+{
+    return std::unique_ptr<MenuItemHandler, MenuItemHandlerDeleter>(
+        [[MenuItemHandler alloc] initWithCallback:[=]()
+        {
+            menuItem->NotifyOnClicked(menuItem);
+        }]);
+}
+
+std::unique_ptr<NSMenu, NSMenuDeleter> CreateNSMenu()
+{
+    return std::unique_ptr<NSMenu, NSMenuDeleter>([[NSMenu alloc] init]);
+}
+
+std::unique_ptr<NSMenuItem, NSMenuItemDeleter> CreateNSMenuItem(const MenuItemOptions& options)
+{
+    auto item = [[NSMenuItem alloc] init];
+    item.title = [[NSString alloc] initWithCString:options.Label encoding:NSUTF8StringEncoding];
+    return std::unique_ptr<NSMenuItem, NSMenuItemDeleter>(item);
+}
+
+std::unique_ptr<NSMenuItem, NSMenuItemDeleter> CreateSeparator()
+{
+    return std::unique_ptr<NSMenuItem, NSMenuItemDeleter>([NSMenuItem separatorItem]);
+}
+
+// -------------------------------------------------------------------------------------------------
+// Deleters
+// -------------------------------------------------------------------------------------------------
+
+void NSMenuDeleter::operator()(NSMenu* menu)
+{
+    if (menu != nullptr)
+    {
+        [menu release];
+    }
+}
+
+void NSMenuItemDeleter::operator()(NSMenuItem* menuItem)
+{
+    if (menuItem != nullptr)
+    {
+        [menuItem release];
+    }
+}
+
+void MenuItemHandlerDeleter::operator()(MenuItemHandler* handler)
+{
+    if (handler != nullptr)
+    {
+        [handler release];
+    }
+}
+
+// -------------------------------------------------------------------------------------------------
+// Menu
+// -------------------------------------------------------------------------------------------------
+
+Menu::Menu()
+    : MenuNode()
+    , _menu(CreateNSMenu())
+{
+}
+
+void Menu::Add(MenuNode* child)
+{
+    MenuNode::Add(child);
+    child->AddTo(_menu.get());
+}
+
+void Menu::AddOnClicked(const OnClickedCallback onClicked)
+{
+    _onClicked.push_back(onClicked);
+}
+
+void Menu::AddTo(NSMenu* menu)
+{
+    throw std::logic_error("Menu is a top-level MenuNode.");
+}
+
+void Menu::Hide() const
+{
+    // TODO: Implement this.
+}
+
+void Menu::NotifyOnClicked(MenuItem* item)
+{
+    auto copied = _onClicked;
+
+    for (auto& onClicked : copied)
+    {
+        onClicked(item);
+    }
+}
+
+void Menu::RemoveOnClicked(const OnClickedCallback onClicked)
+{
+    auto index = std::find(_onClicked.begin(), _onClicked.end(), onClicked);
+
+    if (index != _onClicked.end())
+    {
+        _onClicked.erase(index);
+    }
+}
+
+void Menu::Show(const Photino* window, const int x, const int y) const
+{
+    NSPoint position
+    {
+        CGFloat(x),
+        CGFloat(y)
+    };
+
+    [_menu.get() popUpMenuPositioningItem:nil atLocation:position inView:window->_webview];
+}
+
+// -------------------------------------------------------------------------------------------------
+// MenuItem
+// -------------------------------------------------------------------------------------------------
+
+MenuItem::MenuItem(MenuItemOptions options)
+    : MenuNode()
+    , _menuItem(CreateNSMenuItem(options))
+    , _menuItemHandler(CreateMenuItemHandler(this))
+{
+    SEL action = @selector(menuItemAction:);
+    [_menuItem.get() setAction:action];
+    [_menuItem.get() setTarget:_menuItemHandler.get()];
+}
+
+void MenuItem::Add(MenuNode* child)
+{
+    MenuNode::Add(child);
+
+    if (_menu == nullptr)
+    {
+        _menu = CreateNSMenu();
+        [_menuItem.get() setAction:nil];
+        [_menuItem.get() setTarget:nil];
+        [_menuItem.get() setSubmenu:_menu.get()];
+    }
+
+    child->AddTo(_menu.get());
+}
+
+void MenuItem::AddTo(NSMenu* menu)
+{
+    [menu addItem:_menuItem.get()];
+}
+
+void MenuItem::NotifyOnClicked(MenuItem* item)
+{
+    if (parent != nullptr)
+    {
+        parent->NotifyOnClicked(item);
+    }
+}
+
+// -------------------------------------------------------------------------------------------------
+// MenuItemHandler
+// -------------------------------------------------------------------------------------------------
+
+@implementation MenuItemHandler {
+    std::function<void()> _callback;
+}
+
+- (instancetype)initWithCallback:(std::function<void()>)callback
+{
+    self = [super init];
+
+    if (self != nil)
+    {
+        _callback = callback;
+    }
+
+    return self;
+}
+
+- (void)menuItemAction:(id)sender
+{
+    _callback();
+}
+@end
+
+// -------------------------------------------------------------------------------------------------
+// MenuNode
+// -------------------------------------------------------------------------------------------------
+
+MenuNode::MenuNode()
+    : parent(nullptr)
+{
+}
+
+void MenuNode::Add(MenuNode* node)
+{
+    node->parent = this;
+    children.push_back(node);
+}
+
+void MenuNode::NotifyOnClicked(MenuItem *item)
+{
+}
+
+// -------------------------------------------------------------------------------------------------
+// MenuSeparator
+// -------------------------------------------------------------------------------------------------
+
+MenuSeparator::MenuSeparator()
+    : MenuNode()
+    , _menuItem(CreateSeparator())
+{
+}
+
+void MenuSeparator::Add(MenuNode* child)
+{
+    throw std::logic_error("Cannot add a MenuNode to a MenuSeparator.");
+}
+
+void MenuSeparator::AddTo(NSMenu* menu)
+{
+    [menu addItem:_menuItem.get()];
+}
+
+// -------------------------------------------------------------------------------------------------
+// MenuRenderer
+// -------------------------------------------------------------------------------------------------
+
+void MenuRenderer::Destroy(Menu* menu)
+{
+    delete menu;
+}
+

--- a/Photino.Native/Photino.Menu.h
+++ b/Photino.Native/Photino.Menu.h
@@ -1,0 +1,9 @@
+#pragma once
+
+#ifdef __APPLE__
+#include "Photino.Mac.Menu.h"
+#elif __linux__
+#include "Photino.Linux.Menu.h"
+#else
+#include "Photino.Windows.Menu.h"
+#endif

--- a/Photino.Native/Photino.Native.vcxproj
+++ b/Photino.Native/Photino.Native.vcxproj
@@ -243,15 +243,18 @@ COPY .\$(OutDir)WebView2Loader.dll ..\Photino.Test\bin\ARM64\Debug\net8.0\</Comm
   <ItemGroup>
     <ClCompile Include="Exports.cpp" />
     <ClCompile Include="Dependencies\wintoastlib.cpp" />
+    <ClCompile Include="Photino.Errors.cpp" />
     <ClCompile Include="Photino.Linux.cpp" />
     <ClCompile Include="Photino.Linux.Dialog.cpp" />
     <ClCompile Include="Photino.Windows.cpp" />
     <ClCompile Include="Photino.Windows.DarkMode.cpp" />
     <ClCompile Include="Photino.Windows.Dialog.cpp" />
+    <ClCompile Include="Photino.Windows.Menu.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Dependencies\wintoastlib.h" />
     <ClInclude Include="json.hpp" />
+    <ClInclude Include="Photino.Errors.h" />
     <ClInclude Include="Photino.h" />
     <ClInclude Include="Photino.Mac.AppDelegate.h" />
     <ClInclude Include="Photino.Mac.NavigationDelegate.h" />
@@ -260,6 +263,8 @@ COPY .\$(OutDir)WebView2Loader.dll ..\Photino.Test\bin\ARM64\Debug\net8.0\</Comm
     <ClInclude Include="Photino.Mac.WindowDelegate.h" />
     <ClInclude Include="Photino.Mac.UrlSchemeHandler.h" />
     <ClInclude Include="Photino.Dialog.h" />
+    <ClInclude Include="Photino.Menu.h" />
+    <ClInclude Include="Photino.Windows.Menu.h" />
     <ClInclude Include="Photino.Windows.ToastHandler.h" />
     <ClInclude Include="Photino.Windows.DarkMode.h" />
     <ClInclude Include="resource.h" />

--- a/Photino.Native/Photino.Tests.cpp
+++ b/Photino.Native/Photino.Tests.cpp
@@ -1,0 +1,2 @@
+#define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
+#include "Dependencies/doctest.h"

--- a/Photino.Native/Photino.Windows.Menu.cpp
+++ b/Photino.Native/Photino.Windows.Menu.cpp
@@ -1,0 +1,585 @@
+﻿#include <algorithm>
+#include <codecvt>
+#include <locale>
+#include <string>
+#include <functional>
+#include "Photino.Windows.Menu.h"
+
+// -------------------------------------------------------------------------------------------------
+// Variables
+// -------------------------------------------------------------------------------------------------
+
+static std::atomic<int> lastMenuItemId;
+static std::atomic<int> lastWindowClassId;
+MenuRenderer menuRenderer{};
+
+// -------------------------------------------------------------------------------------------------
+// Utilities
+// -------------------------------------------------------------------------------------------------
+
+static std::wstring GenerateClassName()
+{
+	return L"Win32Window" + std::to_wstring(lastWindowClassId++);
+}
+
+static std::unique_ptr<std::remove_pointer<HMENU>::type, Win32MenuDeleter> Win32_CreateMenu()
+{
+	auto result = CreatePopupMenu();
+
+	if (!result)
+	{
+		throw Win32Exception{};
+	}
+
+	return std::unique_ptr<std::remove_pointer<HMENU>::type, Win32MenuDeleter>(result);
+}
+
+static std::unique_ptr<std::remove_pointer<HWND>::type, Win32WindowDeleter> Win32_CreateWindow(
+	const ATOM windowClass)
+{
+	auto result = CreateWindow(
+		reinterpret_cast<LPCWSTR>(windowClass),
+		nullptr,
+		0,
+		0,
+		0,
+		0,
+		0,
+		nullptr,
+		nullptr,
+		GetModuleHandle(nullptr),
+		nullptr);
+
+	if (!result)
+	{
+		throw Win32Exception{};
+	}
+
+	return std::unique_ptr<std::remove_pointer<HWND>::type, Win32WindowDeleter>(result);
+}
+
+static std::unique_ptr<std::remove_pointer<LPCWSTR>::type, Win32WindowClassDeleter>
+Win32_CreateWindowClass(const WNDPROC wndProc)
+{
+	std::wstring className = GenerateClassName();
+
+	WNDCLASSEX wndClass;
+
+	wndClass.cbSize = sizeof(wndClass);
+	wndClass.style = 0;
+	wndClass.lpfnWndProc = wndProc;
+	wndClass.cbClsExtra = 0;
+	wndClass.cbWndExtra = 0;
+	wndClass.hInstance = GetModuleHandle(nullptr);
+	wndClass.hIcon = nullptr;
+	wndClass.hCursor = LoadIcon(nullptr, IDC_ARROW);
+	wndClass.hbrBackground = static_cast<HBRUSH>(GetStockObject(BLACK_BRUSH));
+	wndClass.lpszMenuName = nullptr;
+	wndClass.lpszClassName = className.c_str();
+	wndClass.hIconSm = nullptr;
+
+	auto result = RegisterClassEx(&wndClass);
+
+	if (!result)
+	{
+		throw Win32Exception{};
+	}
+
+	return std::unique_ptr<std::remove_pointer<LPCWSTR>::type, Win32WindowClassDeleter>(
+		reinterpret_cast<LPCWSTR>(result),
+		Win32WindowClassDeleter(wndClass.hInstance));
+}
+
+static std::string ToUTF8(const std::wstring& value)
+{
+	std::wstring_convert<std::codecvt_utf8<wchar_t>> converter;
+	return converter.to_bytes(value);
+}
+
+static std::wstring ToUTF16(const std::string& value)
+{
+	std::wstring_convert<std::codecvt_utf8<wchar_t>> converter;
+	return converter.from_bytes(value);
+}
+
+static std::string ToLastErrorString(const DWORD lastError)
+{
+	LPTSTR errorText = nullptr;
+
+	FormatMessage(
+		FORMAT_MESSAGE_ALLOCATE_BUFFER
+		| FORMAT_MESSAGE_FROM_SYSTEM
+		| FORMAT_MESSAGE_IGNORE_INSERTS,
+		nullptr,
+		lastError,
+		MAKELANGID(LANG_ENGLISH, SUBLANG_ENGLISH_US),
+		reinterpret_cast<LPTSTR>(&errorText),
+		0,
+		nullptr);
+
+	if (errorText == nullptr)
+	{
+		return "Failed to format win32 error.";
+	}
+
+	std::wstring errorString(errorText);
+	LocalFree(errorText);
+	return ToUTF8(errorString);
+}
+
+// -------------------------------------------------------------------------------------------------
+// MenuRenderer
+// -------------------------------------------------------------------------------------------------
+
+static LRESULT MenuRendererWndProc(HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam) noexcept
+{
+	switch (msg)
+	{
+		case WM_CLOSE:
+		{
+			auto menuRenderer = reinterpret_cast<MenuRenderer*>(
+				GetWindowLongPtr(hWnd, GWLP_USERDATA));
+
+			if (menuRenderer == nullptr)
+			{
+				break; // TODO: Log this error.
+			}
+
+			menuRenderer->_hWnd = nullptr;
+			PostQuitMessage(0);
+			return 0;
+		}
+		case WM_USER:
+		{
+			auto menuRenderer = reinterpret_cast<MenuRenderer*>(
+				GetWindowLongPtr(hWnd, GWLP_USERDATA));
+
+			if (menuRenderer == nullptr)
+			{
+				break; // TODO: Log this error.
+			}
+
+			try
+			{
+				auto command = reinterpret_cast<std::function<void(HWND)>*>(lParam);
+				(*command)(hWnd);
+				delete command;
+			}
+			catch (std::exception)
+			{
+				// TODO: Log this error.
+			}
+
+			break;
+		}
+	}
+
+	return DefWindowProc(hWnd, msg, wParam, lParam);
+}
+
+MenuRenderer::MenuRenderer()
+	: _activeMenu(NULL)
+	, _thread(MenuRenderer::PumpMessages, this)
+{
+}
+
+MenuRenderer::~MenuRenderer()
+{
+	{
+		std::lock_guard<std::mutex> lock(_hWndMutex);
+		PostMessage(_hWnd.get(), WM_CLOSE, 0, 0);
+	}
+
+	_thread.join();
+}
+
+void MenuRenderer::Destroy(Menu* menu)
+{
+	// First, post `DestroyMenuCommand` since `TrackPopupMenuEx` begins a
+	// modal window and cannot process this message until the menu is
+	// dismissed.
+
+	PostMessage(
+		_hWnd.get(),
+		WM_USER,
+		0,
+		reinterpret_cast<LPARAM>(new std::function<void(HWND)>([=](HWND hwnd){ delete menu; })));
+
+	// Then, once the message is queued, attempt to hide the menu if
+	// it is currently being tracked. This frees up the event loop to
+	// process the queued `DestroyMenuCommand`.
+
+	Hide(menu);
+}
+
+void MenuRenderer::Hide(const Menu* menu)
+{
+	std::lock_guard<std::mutex> lock(_activeMenuMutex);
+
+	if (_activeMenu == menu)
+	{
+		PostMessage(_hWnd.get(), WM_CANCELMODE, 0, 0);
+	}
+}
+
+void MenuRenderer::PumpMessages(MenuRenderer* renderer) noexcept
+{
+	try
+	{
+		{
+			std::lock_guard<std::mutex> lock(renderer->_hWndMutex);
+			auto windowClass = Win32_CreateWindowClass(MenuRendererWndProc);
+			auto window = Win32_CreateWindow(reinterpret_cast<ATOM>(windowClass.get()));
+			SetWindowLongPtr(window.get(), GWLP_USERDATA, reinterpret_cast<LONG_PTR>(renderer));
+			renderer->_hWnd = std::move(window);
+		}
+
+		while (true)
+		{
+			MSG msg;
+
+			switch (GetMessage(&msg, nullptr, 0, 0))
+			{
+				case -1:
+				{
+					return; // TODO: Log this error.
+				}
+				case 0:
+				{
+					return;
+				}
+				default:
+				{
+					TranslateMessage(&msg);
+					DispatchMessage(&msg);
+					break;
+				}
+			}
+		}
+	}
+	catch (std::exception)
+	{
+		// TODO: Log this error.
+	}
+}
+
+void MenuRenderer::Show(Menu* menu, const int x, const int y) const
+{
+	PostMessage(
+		_hWnd.get(),
+		WM_USER,
+		0,
+		reinterpret_cast<LPARAM>(new std::function<void(HWND)>([=](HWND hwnd) {
+			{
+				std::lock_guard<std::mutex> lock(menuRenderer._activeMenuMutex);
+				menuRenderer._activeMenu = menu;
+			}
+
+			// Since our commands run on a different thread than the main window, we must bring our
+			// menu thread to the foreground before tracking the popup menu to ensure that dismissal
+			// works correctly.
+
+			if (!SetForegroundWindow(hwnd))
+			{
+				// TODO: Log this error.
+			}
+
+			SetLastError(0);
+
+			auto itemId = TrackPopupMenuEx(
+				menu->_menu.get(),
+				TPM_LEFTALIGN | TPM_RETURNCMD | TPM_TOPALIGN,
+				x,
+				y,
+				hwnd,
+				nullptr);
+
+			{
+				std::lock_guard<std::mutex> lock(menuRenderer._activeMenuMutex);
+				menuRenderer._activeMenu = nullptr;
+			}
+
+			if (!itemId)
+			{
+				auto lastError = GetLastError();
+
+				if (lastError)
+				{
+					throw Win32Exception(lastError);
+				}
+
+				menu->NotifyClicked(nullptr);
+			}
+			else
+			{
+				MENUITEMINFO info = {};
+
+				info.cbSize = sizeof(info);
+				info.fMask = MIIM_DATA;
+
+				if (!GetMenuItemInfo(menu->_menu.get(), itemId, false, &info))
+				{
+					throw Win32Exception();
+				}
+
+				menu->NotifyClicked(reinterpret_cast<MenuItem*>(info.dwItemData));
+			}
+		})));
+}
+
+// -------------------------------------------------------------------------------------------------
+// Menu
+// -------------------------------------------------------------------------------------------------
+
+Menu::Menu()
+	: MenuNode()
+	, _menu(Win32_CreateMenu())
+{
+}
+
+void Menu::Add(MenuNode* node)
+{
+	MenuNode::Add(node);
+	node->AddTo(_menu.get());
+}
+
+void Menu::AddTo(HMENU hmenu)
+{
+	throw std::logic_error("Menu is a top-level MenuNode.");
+}
+
+void Menu::AddOnClicked(const OnClickedCallback onClicked)
+{
+	const std::lock_guard<std::mutex> lock(_onClickedMutex);
+	_onClicked.push_back(onClicked);
+}
+
+void Menu::Hide() const
+{
+	menuRenderer.Hide(this);
+}
+
+void Menu::NotifyClicked(MenuItem* menuItem)
+{
+	std::vector<OnClickedCallback> copied;
+
+	{
+		const std::lock_guard<std::mutex> lock(_onClickedMutex);
+		copied = std::vector<OnClickedCallback>(_onClicked);
+	}
+
+	for (auto onClicked : copied)
+	{
+		onClicked(menuItem);
+	}
+}
+
+void Menu::RemoveOnClicked(const OnClickedCallback onClicked)
+{
+	const std::lock_guard<std::mutex> lock(_onClickedMutex);
+	auto index = std::find(_onClicked.begin(), _onClicked.end(), onClicked);
+
+	if (index != _onClicked.end())
+	{
+		_onClicked.erase(index);
+	}
+}
+
+void Menu::Show(const Photino* photino, const int x, const int y)
+{
+	POINT point =
+	{
+		x,
+		y
+	};
+
+	if (!ClientToScreen(photino->getHwnd(), &point))
+	{
+		throw Win32Exception{};
+	}
+
+	menuRenderer.Show(this, point.x, point.y);
+}
+
+// -------------------------------------------------------------------------------------------------
+// MenuItem
+// -------------------------------------------------------------------------------------------------
+
+MenuItem::MenuItem(MenuItemOptions options)
+	: MenuNode()
+	, _id(++lastMenuItemId)
+	, _label(options.Label == nullptr
+		? std::wstring()
+		: ToUTF16(options.Label))
+{
+}
+
+void MenuItem::Add(MenuNode* node)
+{
+	MenuNode::Add(node);
+
+	if (_menu == nullptr)
+	{
+		_menu = Win32_CreateMenu();
+
+		MENUITEMINFO info;
+
+		info.cbSize = sizeof(info);
+		info.fMask = MIIM_SUBMENU;
+		info.hSubMenu = _menu.get();
+
+		SetMenuItemInfo(
+			_parentMenu,
+			_id,
+			false,
+			&info);
+	}
+
+	node->AddTo(_menu.get());
+}
+
+void MenuItem::AddTo(HMENU hMenu)
+{
+	_parentMenu = hMenu;
+
+	UINT uFlags = MF_STRING;
+	UINT_PTR uIDNewItem = _id;
+	LPCWSTR lpNewItem = const_cast<wchar_t*>(_label.c_str());
+
+	if (!AppendMenu(hMenu, uFlags, uIDNewItem, lpNewItem))
+	{
+		throw Win32Exception();
+	}
+
+	MENUITEMINFO info = {};
+
+	info.cbSize = sizeof(info);
+	info.dwItemData = reinterpret_cast<ULONG_PTR>(this);
+	info.fMask = MIIM_DATA | MIIM_SUBMENU;
+	info.hSubMenu = _menu.get();
+
+	SetMenuItemInfo(hMenu, _id, false, &info);
+}
+
+// -------------------------------------------------------------------------------------------------
+// MenuNode
+// -------------------------------------------------------------------------------------------------
+
+MenuNode::MenuNode()
+	: parent(nullptr)
+{
+}
+
+void MenuNode::Add(MenuNode* node)
+{
+	node->parent = this;
+	node->children.push_back(node);
+}
+
+void MenuNode::NotifyOnClicked(MenuItem* item)
+{
+}
+
+// -------------------------------------------------------------------------------------------------
+// MenuSeparator
+// -------------------------------------------------------------------------------------------------
+
+void MenuSeparator::Add(MenuNode* node)
+{
+	throw std::logic_error("Cannot add a MenuNode to a MenuSeparator.");
+}
+
+void MenuSeparator::AddTo(HMENU hMenu)
+{
+	if (!AppendMenu(hMenu, MF_SEPARATOR, 0, nullptr))
+	{
+		throw Win32Exception();
+	}
+}
+
+// -------------------------------------------------------------------------------------------------
+// Win32BitmapDeleter
+// -------------------------------------------------------------------------------------------------
+
+void Win32BitmapDeleter::operator()(HBITMAP hBitmap) const noexcept
+{
+	if (hBitmap == nullptr)
+	{
+		return;
+	}
+
+	if (!DeleteObject(hBitmap))
+	{
+		// TODO: Log this error.
+	}
+}
+
+// -------------------------------------------------------------------------------------------------
+// Win32Exception
+// -------------------------------------------------------------------------------------------------
+
+Win32Exception::Win32Exception()
+	: std::runtime_error(ToLastErrorString(GetLastError()))
+{
+}
+
+Win32Exception::Win32Exception(DWORD lastError)
+	: std::runtime_error(ToLastErrorString(lastError))
+{
+}
+
+// -------------------------------------------------------------------------------------------------
+// Win32MenuDeleter
+// -------------------------------------------------------------------------------------------------
+
+void Win32MenuDeleter::operator()(HMENU hMenu) const noexcept
+{
+	if (hMenu == nullptr)
+	{
+		return;
+	}
+
+	if (!DestroyMenu(hMenu))
+	{
+		// TODO: Log this error.
+	}
+}
+
+// -------------------------------------------------------------------------------------------------
+// Win32WindowDeleter
+// -------------------------------------------------------------------------------------------------
+
+void Win32WindowDeleter::operator()(HWND hWnd) const noexcept
+{
+	if (hWnd == nullptr)
+	{
+		return;
+	}
+
+	if (!DestroyWindow(hWnd))
+	{
+		// TODO: Log this error.
+	}
+}
+
+// -------------------------------------------------------------------------------------------------
+// Win32WindowClassDeleter
+// -------------------------------------------------------------------------------------------------
+
+Win32WindowClassDeleter::Win32WindowClassDeleter(HINSTANCE hInstance) noexcept
+	: _hInstance(hInstance)
+{
+}
+
+void Win32WindowClassDeleter::operator()(LPCWSTR atom) const noexcept
+{
+	if (atom == 0)
+	{
+		return;
+	}
+
+	if (!UnregisterClass(reinterpret_cast<LPCWSTR>(atom), _hInstance))
+	{
+		// TODO: Log this error.
+	}
+}

--- a/Photino.Native/Photino.Windows.Menu.h
+++ b/Photino.Native/Photino.Windows.Menu.h
@@ -1,0 +1,123 @@
+#pragma once
+#include <atomic>
+#include <memory>
+#include <mutex>
+#include <stdexcept>
+#include <string>
+#include <thread>
+#include <vector>
+#include <windows.h>
+#include "Photino.h"
+
+class Menu;
+class MenuItem;
+class MenuItemOptions;
+class MenuNode;
+class MenuRenderer;
+class MenuSeparator;
+class Win32Exception;
+
+typedef void (*OnClickedCallback)(MenuItem* menuItem);
+
+struct Win32BitmapDeleter final
+{
+	void operator()(HBITMAP hBitmap) const noexcept;
+};
+
+struct Win32MenuDeleter final
+{
+	void operator()(HMENU hMenu) const noexcept;
+};
+
+struct Win32WindowClassDeleter final
+{
+private:
+	HINSTANCE _hInstance;
+public:
+	Win32WindowClassDeleter(HINSTANCE hInstance) noexcept;
+	void operator()(LPCWSTR atom) const noexcept;
+};
+
+struct Win32WindowDeleter final
+{
+	void operator()(HWND hWnd) const noexcept;
+};
+
+struct MenuNode
+{
+	std::vector<MenuNode*> children;
+	MenuNode* parent;
+	MenuNode();
+	virtual ~MenuNode() = default;
+	virtual void Add(MenuNode* node);
+	virtual void AddTo(HMENU hMenu) = 0;
+	virtual void NotifyOnClicked(MenuItem* item);
+};
+
+class Menu final : public MenuNode
+{
+private:
+	std::vector<MenuNode> _children;
+	std::vector<OnClickedCallback> _onClicked;
+	std::mutex _onClickedMutex;
+public:
+	std::unique_ptr<std::remove_pointer<HMENU>::type, Win32MenuDeleter> _menu;
+	Menu();
+	void Add(MenuNode* node) override;
+	void AddTo(HMENU hmenu) override;
+	void AddOnClicked(const OnClickedCallback onClicked);
+	void Hide() const;
+	void NotifyClicked(MenuItem* menuItem);
+	void RemoveOnClicked(const OnClickedCallback onClicked);
+	void Show(const Photino* window, const int x, const int y);
+};
+
+class MenuItem final : public MenuNode
+{
+private:
+	int _id;
+	std::wstring _label;
+	std::unique_ptr<std::remove_pointer<HMENU>::type, Win32MenuDeleter> _menu;
+	HMENU _parentMenu;
+public:
+	MenuItem(MenuItemOptions options);
+	void Add(MenuNode* node) override;
+	void AddTo(HMENU hMenu) override;
+};
+
+struct MenuItemOptions final
+{
+	char* Label;
+};
+
+class MenuRenderer final
+{
+	friend LRESULT MenuRendererWndProc(HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam) noexcept;
+private:
+	Menu* _activeMenu;
+	std::mutex _activeMenuMutex;
+	std::unique_ptr<std::remove_pointer<HWND>::type, Win32WindowDeleter> _hWnd;
+	std::mutex _hWndMutex;
+	std::thread _thread;
+	static void PumpMessages(MenuRenderer* renderer) noexcept;
+public:
+	MenuRenderer();
+	~MenuRenderer();
+	void Destroy(Menu* menu);
+	void Hide(const Menu* menu);
+	void Show(Menu* menu, const int x, const int y) const;
+};
+
+struct MenuSeparator final : public MenuNode
+{
+	void Add(MenuNode* node) override;
+	void AddTo(HMENU hMenu) override;
+};
+
+struct Win32Exception final : public std::runtime_error
+{
+	Win32Exception();
+	Win32Exception(DWORD lastError);
+};
+
+extern MenuRenderer menuRenderer;

--- a/Photino.Native/Photino.Windows.cpp
+++ b/Photino.Native/Photino.Windows.cpp
@@ -51,6 +51,11 @@ const HBRUSH lightBrush = CreateSolidBrush(RGB(255, 255, 255));
 
 void Photino::Register(HINSTANCE hInstance)
 {
+	if (!SUCCEEDED(CoInitializeEx(NULL, COINIT_APARTMENTTHREADED)))
+	{
+		// TODO: Handle failure to initialize COM.
+	}
+
 	InitDarkModeSupport();
 
 	_hInstance = hInstance;
@@ -318,7 +323,7 @@ Photino::~Photino()
 	if (_notificationsEnabled && _toastHandler != NULL) delete _toastHandler;
 }
 
-HWND Photino::getHwnd()
+HWND Photino::getHwnd() const
 {
 	return _hWnd;
 }

--- a/Photino.Native/Photino.h
+++ b/Photino.Native/Photino.h
@@ -173,13 +173,10 @@ private:
 	
 #elif __linux__
 	// GtkWidget* _window;
-	GtkWidget *_webview;
 	GdkGeometry _hints;
 	void AddCustomSchemeHandlers();
 	bool _isFullScreen;
 #elif __APPLE__
-	NSWindow *_window;
-	WKWebView *_webview;
 	WKWebViewConfiguration *_webviewConfiguration;
 	std::vector<Monitor *> GetMonitors();
 	
@@ -212,7 +209,7 @@ public:
 #ifdef _WIN32
 	static void Register(HINSTANCE hInstance);
 	static void SetWebView2RuntimePath(AutoString pathToWebView2);
-	HWND getHwnd();
+	HWND getHwnd() const;
 	void RefitContent();
 	void FocusWebView2();
 	void NotifyWebView2WindowMove();
@@ -226,6 +223,7 @@ public:
 #elif __linux__
 	void set_webkit_settings();
 	void set_webkit_customsettings(WebKitSettings* settings);
+	GtkWidget *_webview;
 	GtkWidget *_window;
 	int _lastHeight;
 	int _lastWidth;
@@ -236,6 +234,8 @@ public:
 	int _maxWidth;
 	int _maxHeight;
 #elif __APPLE__
+	NSWindow *_window;
+	WKWebView *_webview;
 	static void Register();
 #endif
 


### PR DESCRIPTION
## What does the pull request do?

This pull request adds support for menus on the Windows platform via win32 APIs.

![win32_menus](https://github.com/user-attachments/assets/13a7f2e7-6d46-43dc-a5fc-31d7dd8ce66d)
![linux_menus](https://github.com/user-attachments/assets/ac11a826-1b1b-4716-8cb6-586ca6d7db12)
![mac_menus](https://github.com/user-attachments/assets/21061aa1-f4d2-4070-b115-7ff3651d2b70)

## What is the current behavior?

Currently, there is no support for native menus.

## What is the expected behavior?

There should be support for native menus.

## How was the solution implemented?

Due to WebView2's [threading model](https://learn.microsoft.com/en-us/microsoft-edge/webview2/concepts/threading-model), we can't simply execute [TrackPopupMenu](https://learn.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-trackpopupmenu). Thus, we choose to create a "menu thread" on which all of our menu operations occur. We communicate with the C# via a `OnClicked` callback, and we expect C# to properly `Invoke` on the relevant `PhotinoWindow`.

## Fixed issues

#43 

## Remarks

@philippjbauer @MikeYeager 