### PR TITLE
Fix Linux build command in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,19 @@ The GitHub repository includes .yml files for automated CI/CD builds, packaging 
 
 * Windows - Open the solution in Visual Studio 2019 or later with the **Desktop development with C++** workload installed. The **Linux development with C++** workload is recommended, but not required. You *must* build in x64 configuration (*not* AnyCPU which is the default). You *must* install either the [WebView2 runtime]( https://go.microsoft.com/fwlink/p/?LinkId=2124703 ) or the [Edge Dev Channel]( https://www.microsoftedgeinsider.com/en-us/download ). Beta and Canary should work as well, but that hasn't been verified. Just having Edge Chromium installed will not work. The project will build, but will not work properly in a development environment.
   
-* Linux - (Tested with Ubuntu 18.04 and 20.04) Install dependencies: `sudo apt-get update && sudo apt-get install libgtk-3-dev libwebkit2gtk-4.0-dev libnotify-dev`. To compile, run `gcc -std=c++11 -shared -DOS_LINUX Exports.cpp Photino.Linux.cpp -o x64/$(buildConfiguration)/Photino.Native.so 'pkg-config --cflags --libs gtk+-3.0 webkit2gtk-4.0 libnotify' -fPIC`
+* Linux - (Tested with Ubuntu 18.04 and 20.04) Install dependencies: 
+  ```
+  sudo apt-get update && sudo apt-get install libgtk-3-dev libwebkit2gtk-4.0-dev libnotify-dev
+  ```
+  
+  To compile, replace $(buildConfiguration) with `Release` and run 
+  ```
+  gcc -std=c++11 -shared -DOS_LINUX Exports.cpp Photino.Linux.cpp Photino.Linux.Dialog.cpp -o x64/$(buildConfiguration)/Photino.Native.so `pkg-config --cflags --libs gtk+-3.0 webkit2gtk-4.0 libnotify` -fPIC
+  ```
 
-* Mac - Install Xcode. To compile, run `gcc -shared -lstdc++ -DOS_MAC -framework Cocoa -framework WebKit Photino.Mac.mm Exports.cpp Photino.Mac.AppDelegate.mm Photino.Mac.UiDelegate.mm Photino.Mac.UrlSchemeHandler.mm -o x64/$(buildConfiguration)/Photino.Native.dylib`.
+* Mac - Install Xcode. 
+  
+  To compile, replace $(buildConfiguration) with `Release` and run 
+  ```
+  gcc -shared -lstdc++ -DOS_MAC -framework Cocoa -framework WebKit Photino.Mac.mm Exports.cpp Photino.Mac.AppDelegate.mm Photino.Mac.UiDelegate.mm Photino.Mac.UrlSchemeHandler.mm -o x64/$(buildConfiguration)/Photino.Native.dylib
+  ```


### PR DESCRIPTION
Photino.Linux.Dialog.cpp was missing and as a Linux newbe I did not check that ' should be \` for `pkg-config` sub-command.
With a little help from my search machine I could get `gcc` running and Photino.Native got compiled :-)

The reason why I even had to compile this library is the issue that Photino.Native V4.0.22 (and also 4.0.16) was compiled on a Linux distro which has libc6 V2.38 installed and so it cannot be used on Debian V12.x because V2.36 is the most recent version of libc6.