### PR TITLE
Fixing multiple scaling related issues

### DIFF
--- a/Photino.Native/Exports.cpp
+++ b/Photino.Native/Exports.cpp
@@ -71,6 +71,11 @@ extern "C"
 		instance->GetContextMenuEnabled(enabled);
 	}
 
+    EXPORTED void Photino_GetZoomEnabled(Photino* instance, bool* enabled)
+	{
+	    instance->GetZoomEnabled(enabled);
+	}
+
 	EXPORTED void Photino_GetDevToolsEnabled(Photino* instance, bool* enabled)
 	{
 		instance->GetDevToolsEnabled(enabled);
@@ -199,6 +204,11 @@ extern "C"
 	EXPORTED void Photino_SetContextMenuEnabled(Photino* instance, bool enabled)
 	{
 		instance->SetContextMenuEnabled(enabled);
+	}
+
+    EXPORTED void Photino_SetZoomEnabled(Photino* instance, bool enabled)
+	{
+	    instance->SetZoomEnabled(enabled);
 	}
 
 	EXPORTED void Photino_SetDevToolsEnabled(Photino* instance, bool enabled)

--- a/Photino.Native/Photino.Linux.cpp
+++ b/Photino.Native/Photino.Linux.cpp
@@ -123,6 +123,7 @@ Photino::Photino(PhotinoInitParams *initParams) : _webview(nullptr)
 
 	_transparentEnabled = initParams->Transparent;
 	_contextMenuEnabled = initParams->ContextMenuEnabled;
+	_zoomEnabled = true; // initParams->ZoomEnabled;
 	_devToolsEnabled = initParams->DevToolsEnabled;
 	_grantBrowserPermissions = initParams->GrantBrowserPermissions;
 	_mediaAutoplayEnabled = initParams->MediaAutoplayEnabled;
@@ -346,6 +347,11 @@ void Photino::GetTransparentEnabled(bool *enabled)
 void Photino::GetContextMenuEnabled(bool *enabled)
 {
 	*enabled = _contextMenuEnabled;
+}
+
+void Photino::GetZoomEnabled(bool *enabled)
+{
+    *enabled = _zoomEnabled;
 }
 
 void Photino::GetDevToolsEnabled(bool *enabled)
@@ -582,6 +588,11 @@ void Photino::SendWebMessage(AutoString message)
 void Photino::SetContextMenuEnabled(bool enabled)
 {
 	_contextMenuEnabled = enabled;
+}
+
+void Photino::SetZoomEnabled(bool enabled)
+{
+    //! Not implemented (supported?) on Linux
 }
 
 void Photino::SetDevToolsEnabled(bool enabled)

--- a/Photino.Native/Photino.Mac.mm
+++ b/Photino.Native/Photino.Mac.mm
@@ -136,6 +136,7 @@ Photino::Photino(PhotinoInitParams* initParams)
 
     _ignoreCertificateErrorsEnabled = initParams->IgnoreCertificateErrorsEnabled;
 	_contextMenuEnabled = true; //not configurable on mac //initParams->ContextMenuEnabled;
+	_zoomEnabled = true; // initParams->ZoomEnabled;
 	// _zoom = initParams->Zoom;
     _grantBrowserPermissions = initParams->GrantBrowserPermissions;
 
@@ -368,6 +369,11 @@ void Photino::GetTransparentEnabled(bool* enabled)
 void Photino::GetContextMenuEnabled(bool* enabled)
 {
     *enabled = _contextMenuEnabled;
+}
+
+void Photino::GetZoomEnabled(bool* enabled)
+{
+    *enabled = _zoomEnabled;
 }
 
 void Photino::GetDevToolsEnabled(bool* enabled)
@@ -606,6 +612,11 @@ void Photino::SetTransparentEnabled(bool enabled)
 void Photino::SetContextMenuEnabled(bool enabled)
 {
     //! Not supported on macOS
+}
+
+void Photino::SetZoomEnabled(bool enabled)
+{
+    //! Not implemented (supported?) on macOS
 }
 
 void Photino::SetIconFile(AutoString filename)

--- a/Photino.Native/Photino.Windows.cpp
+++ b/Photino.Native/Photino.Windows.cpp
@@ -168,6 +168,7 @@ Photino::Photino(PhotinoInitParams* initParams)
 
 	_transparentEnabled = initParams->Transparent;
 	_contextMenuEnabled = initParams->ContextMenuEnabled;
+	_zoomEnabled = initParams->ZoomEnabled;
 	_devToolsEnabled = initParams->DevToolsEnabled;
 	_grantBrowserPermissions = initParams->GrantBrowserPermissions;
 	_mediaAutoplayEnabled = initParams->MediaAutoplayEnabled;
@@ -542,6 +543,13 @@ void Photino::GetContextMenuEnabled(bool* enabled)
 	settings->get_AreDefaultContextMenusEnabled((BOOL*)enabled);
 }
 
+void Photino::GetZoomEnabled(bool* enabled)
+{
+    ICoreWebView2Settings* settings;
+    HRESULT r = _webviewWindow->get_Settings(&settings);
+    settings->get_IsZoomControlEnabled((BOOL*)enabled);
+}
+
 void Photino::GetDevToolsEnabled(bool* enabled)
 {
 	ICoreWebView2Settings* settings;
@@ -717,6 +725,14 @@ void Photino::SetContextMenuEnabled(bool enabled)
 	HRESULT r = _webviewWindow->get_Settings(&settings);
 	settings->put_AreDefaultContextMenusEnabled(enabled);
 	_webviewWindow->Reload();
+}
+
+void Photino::SetZoomEnabled(bool enabled)
+{
+    ICoreWebView2Settings* settings;
+    HRESULT r = _webviewWindow->get_Settings(&settings);
+    settings->put_IsZoomControlEnabled(enabled);
+    _webviewWindow->Reload();
 }
 
 void Photino::SetDevToolsEnabled(bool enabled)
@@ -1108,6 +1124,9 @@ void Photino::AttachWebView()
 
 						if (_contextMenuEnabled == false)
 							SetContextMenuEnabled(false);
+
+						if (_zoomEnabled == false)
+							SetZoomEnabled(false);
 
 						if (_devToolsEnabled == false)
 							SetDevToolsEnabled(false);

--- a/Photino.Native/Photino.Windows.cpp
+++ b/Photino.Native/Photino.Windows.cpp
@@ -72,7 +72,7 @@ void Photino::Register(HINSTANCE hInstance)
 
 	RegisterClassEx(&wcx);
 
-	SetThreadDpiAwarenessContext(DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE);
+	SetThreadDpiAwarenessContext(DPI_AWARENESS_CONTEXT_UNAWARE_GDISCALED);
 }
 
 Photino::Photino(PhotinoInitParams* initParams)

--- a/Photino.Native/Photino.Windows.cpp
+++ b/Photino.Native/Photino.Windows.cpp
@@ -750,8 +750,6 @@ void Photino::SetFullScreen(bool fullScreen)
 	{
 		style |= WS_POPUP;
 		style &= (~WS_OVERLAPPEDWINDOW);
-		SetPosition(0, 0);
-		SetSize(GetSystemMetrics(SM_CXSCREEN), GetSystemMetrics(SM_CYSCREEN));
 	}
 	else
 	{
@@ -759,6 +757,11 @@ void Photino::SetFullScreen(bool fullScreen)
 		style &= (~WS_POPUP);
 	}
 	SetWindowLongPtr(_hWnd, GWL_STYLE, style);
+	if (fullScreen)
+	{
+		SetPosition(0, 0);
+		SetSize(GetSystemMetrics(SM_CXSCREEN), GetSystemMetrics(SM_CYSCREEN));
+	}
 }
 
 void Photino::SetIconFile(AutoString filename)

--- a/Photino.Native/Photino.h
+++ b/Photino.Native/Photino.h
@@ -95,6 +95,7 @@ struct PhotinoInitParams
 	bool Chromeless;
 	bool Transparent;
 	bool ContextMenuEnabled;
+	bool ZoomEnabled;
 	bool DevToolsEnabled;
 	bool FullScreen;
 	bool Maximized;
@@ -206,6 +207,7 @@ private:
 
 public:
 	bool _contextMenuEnabled;
+	bool _zoomEnabled;
 
 #ifdef _WIN32
 	static void Register(HINSTANCE hInstance);
@@ -248,6 +250,7 @@ public:
 
 	void GetTransparentEnabled(bool *enabled);
 	void GetContextMenuEnabled(bool *enabled);
+	void GetZoomEnabled(bool *enabled);
 	void GetDevToolsEnabled(bool *enabled);
 	void GetFullScreen(bool *fullScreen);
 	void GetGrantBrowserPermissions(bool *grant);
@@ -277,6 +280,7 @@ public:
 
 	void SetTransparentEnabled(bool enabled);
 	void SetContextMenuEnabled(bool enabled);
+	void SetZoomEnabled(bool enabled);
 	void SetDevToolsEnabled(bool enabled);
 	void SetIconFile(AutoString filename);
 	void SetFullScreen(bool fullScreen);


### PR DESCRIPTION
This PR consists of multiple small changes which are currently essential for our pretty soon product launch. The customer is extremely unhappy with the current scale behavior and it is concidered to remove Photino from the techstack. As an effort to keep Photino im opening up this pull request and hope that we can get this through and a new nuget released before we have to remove photino. The release will not wait for a single library to implement some needed fixes. If there are any concerns i will respond as quickly as possible to get this through.

# Problem 1: DPI_AWARENESS

## Situation:
Windows host using multiple monitors. Every monitor using a different scale.
Having an applicaiton with a fixed min size, in our example of 1280x720.

## Issues:
The MinSize property does not care about any DPI. Opening the window or moving to another Monitor will not updat the MinSize at all, as this is a dpi-unaware pixel property. Whenever the application is shown on a >100% scale screen, you will be able to break the app layout as the window can be smaller.
We tried as a workaround to multiply the scale ourself into the MinSize. This requires to re-calculate on two different events: window-resize and window-move, as its possible that the scale changes either by moving the window onto another screen, or the current screen scale is changed while the application is shown onto it.
Just setting the MinSize wont work, as you also need to update the Size properly as minSize will apply only on the next manual resize, causing the window to not resize when updating the MinSize to a value above the current Size. Manualy changing the size results in a problem: If we size-up, we also need to size-down when we move back to a smaller dpi screen. Otherwise the window will grow but never shrink back. Thats pretty bad for the user experience.
Changing the Size property however while the user is still dragging the window makes the window dimensions glitch out completely. It will flicker between the original size when starting to drag and the new calculated size for every moved pixel.

## Fix:
As Photino is clearly NOT properly dpi aware, the mode DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE is simply wrong. While dpi awareness would be good to have, and photino properly implementing those cases, i decided to not bloat this PR as it requires tinkering on several properties. That could be another pull request to implement proper dpi awareness, see #143. I changed the mode to DPI_AWARENESS_CONTEXT_UNAWARE_GDISCALED which fits the current behavior and not cause all these issues.

# Problem 2: Fullscreen problems

## Situation:
Our application switches into fullscreen mode - nothing special.

## Issue:
When this happens the first time, there is a small black border on the bottom. Debugging the view shows that the webview does not cover the full window. This is obviously a bug, as the webview shoud cover the whole window at all costs. However this only happens the first time we enter fullscreen mode per launch.
Photino sets the window bounds first, then switches over to hiding the window decorations. It seems to be a race condition with windows making sure the window decorations not exceeding the screen bounds, triggering another resize before hiding the window decorations. And this particular resize is sometimes not handled properly. The result is a window with the webview not covering an area in the size of the original window decorations.

## Fix:
I simply changed the order of things to happen: First hide the window decorations, and then updating the bounds. This will prevent windows from resizing the window again and breaking the webview dimensions.

# Problem 3: User-Zoom can break applications

## Situation:
Photino currently does not expose a property to disallow the usage of CTRL+Mousewheel / CTRL+[+/-]. 

## Issue:
Due to not being able to disable user zooming, the user is able to simply zoom inside the application breaking any layout with a fixed min size. There is also no event to hook to eventualy clamp the zoom value into a range of supported scales. However other projects might want to give an user full zooming control.

## Fix:
I added a new ZoomEnabled property which allows to disable the default zoom behavior. As far as i did my research, the webkit apis for linux and osx do not include such an option. But as there are already methods in the codebase which only work for specific platforms, i still added this property which only has effect when using windows. This will be the 99% usecase anyway. If someone finds a way to implement this for OSX or Linux, it can be added afterwards.
When this PR is merged, i will also add a pull request for the Photino.NET library, which has to make this new native method available in the .NET api.