### PR TITLE
Fix nullptr reference crash in IsColorSchemeChange

### DIFF
--- a/Photino.Native/Photino.Windows.DarkMode.cpp
+++ b/Photino.Native/Photino.Windows.DarkMode.cpp
@@ -165,6 +165,9 @@ bool IsColorSchemeChange(LPARAM l_param) noexcept {
         return_value = true;
     }
 
-    GetIsImmersiveColorUsingHighContrast(IHCM_REFRESH);
+    if (GetIsImmersiveColorUsingHighContrast != nullptr) {
+        GetIsImmersiveColorUsingHighContrast(IHCM_REFRESH);
+    }
+
     return return_value;
 }


### PR DESCRIPTION
- It was possible for the WM_SETTINGCHANGED event to get produced on an OS older than `static constexpr DWORD WIN10_MINIMUM_BUILD_DARK_MODE = 18362;` which would result in a crash as `InitDarkModeSupportOnce` would not initialize `GetIsImmersiveColorUsingHighContrast`