### PR TITLE
Fix SetWebView2RuntimePath UTF encoding issue after Photino.NET encoding update

### DIFF
--- a/Photino.Native/Exports.cpp
+++ b/Photino.Native/Exports.cpp
@@ -22,7 +22,7 @@ extern "C"
 
 	EXPORTED void Photino_setWebView2RuntimePath_win32(Photino* instance, AutoString webView2RuntimePath)
 	{
-		Photino::SetWebView2RuntimePath(webView2RuntimePath);
+		instance->SetWebView2RuntimePath(webView2RuntimePath);
 	}
 
 	EXPORTED void Photino_GetNotificationsEnabled(Photino* instance, bool* disabled)

--- a/Photino.Native/Photino.Windows.cpp
+++ b/Photino.Native/Photino.Windows.cpp
@@ -1251,6 +1251,7 @@ void Photino::SetWebView2RuntimePath(AutoString pathToWebView2)
 {
 	if (pathToWebView2 != NULL)
 	{
+        pathToWebView2 = ToUTF16String(pathToWebView2);
 		wcsncpy(_webview2RuntimePath, pathToWebView2, _countof(_webview2RuntimePath));
 	}
 }

--- a/Photino.Native/Photino.h
+++ b/Photino.Native/Photino.h
@@ -209,7 +209,7 @@ public:
 
 #ifdef _WIN32
 	static void Register(HINSTANCE hInstance);
-	static void SetWebView2RuntimePath(AutoString pathToWebView2);
+	void SetWebView2RuntimePath(AutoString pathToWebView2);
 	HWND getHwnd();
 	void RefitContent();
 	void FocusWebView2();


### PR DESCRIPTION
- With the changes introduced to Photino.NET on this update https://github.com/tryphotino/photino.NET/pull/235/files the WebView2RuntimePath needed to convert the string back into a Windows ecosystem UTF16 string for it to be read correctly when using the `Win32SetWebView2Path` function