### PR TITLE
Add functions for dragging and resizing windows

### DIFF
--- a/Photino.Native/Exports.cpp
+++ b/Photino.Native/Exports.cpp
@@ -265,6 +265,16 @@ extern "C"
 	{
 		instance->SetZoom(zoom);
 	}
+
+	EXPORTED void Photino_StartDragging(Photino* instance) 
+	{
+		instance->StartDragging();
+	}
+
+	EXPORTED void Photino_StartResizing(Photino* instance, PhotinoWindowHitTestCode hitTestCode) 
+	{
+		instance->StartResizing(hitTestCode);
+	}
 	
 	EXPORTED void Photino_ShowNotification(Photino* instance, AutoString title, AutoString body)
 	{

--- a/Photino.Native/Photino.Windows.cpp
+++ b/Photino.Native/Photino.Windows.cpp
@@ -858,6 +858,58 @@ void Photino::SetZoom(int zoom)
 }
 
 
+void Photino::StartDragging() 
+{
+	ReleaseCapture();
+	SendMessage(_hWnd, WM_NCLBUTTONDOWN, HTCAPTION, 0);
+}
+
+void Photino::StartResizing(PhotinoWindowHitTestCode hitTestCode)
+{
+	int winHitTestCode = 0;
+
+	switch (hitTestCode)
+	{
+	case PhotinoWindowHitTestCode::Left:
+		winHitTestCode = HTLEFT;
+		break;
+
+	case PhotinoWindowHitTestCode::Right:
+		winHitTestCode = HTRIGHT;
+		break;
+
+	case PhotinoWindowHitTestCode::Top:
+		winHitTestCode = HTTOP;
+		break;
+
+	case PhotinoWindowHitTestCode::Bottom:
+		winHitTestCode = HTBOTTOM;
+		break;
+
+	case PhotinoWindowHitTestCode::TopLeft:
+		winHitTestCode = HTTOPLEFT;
+		break;
+
+	case PhotinoWindowHitTestCode::TopRight:
+		winHitTestCode = HTTOPRIGHT;
+		break;
+
+	case PhotinoWindowHitTestCode::BottomLeft:
+		winHitTestCode = HTBOTTOMLEFT;
+		break;
+
+	case PhotinoWindowHitTestCode::BottomRight:
+		winHitTestCode = HTBOTTOMRIGHT;
+		break;
+	}
+
+	if (winHitTestCode != 0)
+	{
+		ReleaseCapture();
+		SendMessage(_hWnd, WM_NCLBUTTONDOWN, winHitTestCode, 0);
+	}
+}
+
 
 void Photino::ShowNotification(AutoString title, AutoString body)
 {

--- a/Photino.Native/Photino.h
+++ b/Photino.Native/Photino.h
@@ -40,6 +40,18 @@ struct Monitor
 	double scale;
 };
 
+enum class PhotinoWindowHitTestCode 
+{
+	Left,
+	Right,
+	Top,
+	Bottom,
+	TopLeft,
+	TopRight,
+	BottomLeft,
+	BottomRight,
+};
+
 typedef void (*ACTION)();
 typedef void (*WebMessageReceivedCallback)(AutoString message);
 typedef void *(*WebResourceRequestedCallback)(AutoString url, int *outNumBytes, AutoString *outContentType);
@@ -290,6 +302,10 @@ public:
 	void SetTitle(AutoString title);
 	void SetTopmost(bool topmost);
 	void SetZoom(int zoom);
+
+	// Window manipulation
+	void StartDragging();
+	void StartResizing(PhotinoWindowHitTestCode hitTest);
 
 	void ShowNotification(AutoString title, AutoString message);
 	void WaitForExit();

--- a/Photino.Test/Photino.Test.csproj
+++ b/Photino.Test/Photino.Test.csproj
@@ -35,7 +35,8 @@
     <Compile Include="..\..\photino.NET\Photino.NET\PhotinoNativeDelegates.cs" Link="PhotinoNativeDelegates.cs" />
     <Compile Include="..\..\photino.NET\Photino.NET\PhotinoNativeParameters.cs" Link="PhotinoNativeParameters.cs" />
     <Compile Include="..\..\photino.NET\Photino.NET\PhotinoNetDelegates.cs" Link="PhotinoNetDelegates.cs" />
-    <Compile Include="..\..\photino.NET\Photino.NET\PhotinoWindow.NET.cs" Link="PhotinoWindow.NET.cs" />
+	<Compile Include="..\..\photino.NET\Photino.NET\PhotinoWindow.NET.cs" Link="PhotinoWindow.NET.cs" />
+	<Compile Include="..\..\photino.NET\Photino.NET\PhotinoWindowEnums.cs" Link="PhotinoWindowEnums.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Photino.Test/Program.cs
+++ b/Photino.Test/Program.cs
@@ -476,6 +476,42 @@ namespace Photino.NET
             {
                 var result = currentWindow.ShowMessage("Title", "Testing... 🤖");
             }
+            else if (string.Compare(message, "startDragging", true) == 0)
+            {
+                currentWindow.StartDragging();
+            }
+            else if (string.Compare(message, "startResizing-left", true) == 0)
+            {
+                currentWindow.StartResizing(PhotinoWindowHitTestCode.Left);
+            }
+            else if (string.Compare(message, "startResizing-topLeft", true) == 0)
+            {
+                currentWindow.StartResizing(PhotinoWindowHitTestCode.TopLeft);
+            }
+            else if (string.Compare(message, "startResizing-top", true) == 0)
+            {
+                currentWindow.StartResizing(PhotinoWindowHitTestCode.Top);
+            }
+            else if (string.Compare(message, "startResizing-topRight", true) == 0)
+            {
+                currentWindow.StartResizing(PhotinoWindowHitTestCode.TopRight);
+            }
+            else if (string.Compare(message, "startResizing-right", true) == 0)
+            {
+                currentWindow.StartResizing(PhotinoWindowHitTestCode.Right);
+            }
+            else if (string.Compare(message, "startResizing-bottomRight", true) == 0)
+            {
+                currentWindow.StartResizing(PhotinoWindowHitTestCode.BottomRight);
+            }
+            else if (string.Compare(message, "startResizing-bottom", true) == 0)
+            {
+                currentWindow.StartResizing(PhotinoWindowHitTestCode.Bottom);
+            }
+            else if (string.Compare(message, "startResizing-bottomLeft", true) == 0)
+            {
+                currentWindow.StartResizing(PhotinoWindowHitTestCode.BottomLeft);
+            }
             else
                 throw new Exception($"Unknown message '{message}'");
         }

--- a/Photino.Test/wwwroot/main.html
+++ b/Photino.Test/wwwroot/main.html
@@ -138,6 +138,14 @@
             window.external.sendMessage('setMaxSize');
         }
 
+        function StartDragging() {
+            window.external.sendMessage('startDragging');
+        }
+
+        function StartResizing(hitTest) {
+            window.external.sendMessage('startResizing-' + hitTest);
+        }
+
         (() => {
   // The width and height of the captured photo. We will set the
   // width to the value defined here, but the height will be
@@ -278,6 +286,7 @@
     <button onclick="SetTransparent()">Transparent</button>
     <button onclick="SetFullScreen()">Kiosk</button>
     <button onclick="Close()">Close</button>
+    <button onmousedown="StartDragging()">Start Dragging</button>
     <br>
     <b>Size</b><br>
     <button onclick="Minimize()">Minimize</button>
@@ -336,5 +345,80 @@
     </span>
 
     <canvas id="canvas" style="visibility:hidden">required to render the photo, but not visible</canvas>
+
+    <button class="resize resize-left" onmousedown="StartResizing('left')"></button>
+    <button class="resize resize-top-left" onmousedown="StartResizing('topLeft')"></button>
+    <button class="resize resize-top" onmousedown="StartResizing('top')"></button>
+    <button class="resize resize-top-right" onmousedown="StartResizing('topRight')"></button>
+    <button class="resize resize-right" onmousedown="StartResizing('right')"></button>
+    <button class="resize resize-bottom-right" onmousedown="StartResizing('bottomRight')"></button>
+    <button class="resize resize-bottom" onmousedown="StartResizing('bottom')"></button>
+    <button class="resize resize-bottom-left" onmousedown="StartResizing('bottomLeft')"></button>
+
+    <style>
+        body {
+            padding: 10px
+        }
+
+        .resize {
+            position: fixed;
+        }
+
+        .resize-left {
+            width: 10px;
+            top: 10px;
+            left: 0px;
+            bottom: 10px;
+        }
+
+        .resize-top-left {
+            width: 10px;
+            height: 10px;
+            top: 0;
+            left: 0;
+        }
+
+        .resize-top {
+            height: 10px;
+            top: 0;
+            left: 10px;
+            right: 10px;
+        }
+
+        .resize-top-right {
+            width: 10px;
+            height: 10px;
+            top: 0px;
+            right: 0px;
+        }
+
+        .resize-right {
+            width: 10px;
+            top: 10px;
+            right: 0px;
+            bottom: 10px;
+        }
+
+        .resize-bottom-right {
+            width: 10px;
+            height: 10px;
+            right: 0px;
+            bottom: 0px;
+        }
+
+        .resize-bottom {
+            height: 10px;
+            left: 10px;
+            right: 10px;
+            bottom: 0px;
+        }
+
+        .resize-bottom-left {
+            width: 10px;
+            height: 10px;
+            left: 0px;
+            bottom: 0px;
+        }
+    </style>
 </body>
 </html>


### PR DESCRIPTION
This PR adds the ability for windows to be dragged / resized regardless of window chrome. This only addresses Windows platforms.

A "start dragging" button was added to the test window, as well as drag points for resizing.