### PR TITLE
feat: native menu support

### DIFF
--- a/Photino.Native/Exports.cpp
+++ b/Photino.Native/Exports.cpp
@@ -344,4 +344,14 @@ extern "C"
 	{
 		instance->Invoke(callback);
 	}
+
+	EXPORTED void Photino_SetMenu(Photino* instance, AutoString menuJson)
+	{
+		instance->SetMenu(menuJson);
+	}
+
+	EXPORTED void Photino_SetMenuCommandCallback(Photino* instance, MenuCommandCallback callback)
+	{
+		instance->SetMenuCommandCallback(callback);
+	}
 }

--- a/Photino.Native/Photino.Linux.cpp
+++ b/Photino.Native/Photino.Linux.cpp
@@ -152,6 +152,7 @@ Photino::Photino(PhotinoInitParams *initParams) : _webview(nullptr)
 	_minimizedCallback = (MinimizedCallback)initParams->MinimizedHandler;
 	_restoredCallback = (RestoredCallback)initParams->RestoredHandler;
 	_customSchemeCallback = (WebResourceRequestedCallback)initParams->CustomSchemeHandler;
+	_menuCommandCallback = (MenuCommandCallback)initParams->MenuCommandHandler;
 
 	// copy strings from the fixed size array passed, but only if they have a value.
 	for (int i = 0; i < 16; ++i)
@@ -274,6 +275,11 @@ Photino::Photino(PhotinoInitParams *initParams) : _webview(nullptr)
 					 this);
 
 	Photino::AddCustomSchemeHandlers();
+
+	if (initParams->MenuDefinition != NULL && strlen(initParams->MenuDefinition) > 0)
+	{
+		SetMenu(initParams->MenuDefinition);
+	}
 
 	if (initParams->Transparent)
 		Photino::SetTransparentEnabled(true);
@@ -1081,6 +1087,162 @@ void Photino::AddCustomSchemeHandlers()
 	{
 		webkit_web_context_register_uri_scheme(
 			context, value, (WebKitURISchemeRequestCallback)HandleCustomSchemeRequest, (void *)_customSchemeCallback, NULL);
+	}
+}
+
+struct MenuItemData
+{
+	Photino *photino;
+	std::string *command;
+
+	~MenuItemData()
+	{
+		delete command;
+	}
+};
+
+static void menu_item_data_destroy(gpointer userData)
+{
+	MenuItemData *data = (MenuItemData *)userData;
+	delete data;
+}
+
+static void on_menu_item_activate(GtkMenuItem *menuItem, gpointer userData)
+{
+	MenuItemData *data = (MenuItemData *)userData;
+	if (data && data->command)
+		data->photino->InvokeMenuCommand((AutoString)data->command->c_str());
+}
+
+static void BuildMenuItems(GtkWidget *parentMenu, const json &items, Photino *photino)
+{
+	for (const auto &item : items)
+	{
+		if (item.contains("type") && item["type"] == "separator")
+		{
+			gtk_menu_shell_append(GTK_MENU_SHELL(parentMenu), gtk_separator_menu_item_new());
+			continue;
+		}
+
+		if (!item.contains("label") || !item["label"].is_string())
+			continue;
+
+		std::string itemLabelStr = item["label"].get<std::string>();
+
+		if (item.contains("items") && item["items"].is_array())
+		{
+			GtkWidget *subMenuItem = gtk_menu_item_new_with_label(itemLabelStr.c_str());
+			GtkWidget *subMenu = gtk_menu_new();
+			gtk_menu_item_set_submenu(GTK_MENU_ITEM(subMenuItem), subMenu);
+
+			BuildMenuItems(subMenu, item["items"], photino);
+
+			gtk_menu_shell_append(GTK_MENU_SHELL(parentMenu), subMenuItem);
+			continue;
+		}
+
+		if (item.contains("accelerator"))
+		{
+			std::string accel = item["accelerator"].get<std::string>();
+			size_t pos;
+			while ((pos = accel.find("Cmd+")) != std::string::npos)
+				accel.replace(pos, 4, "Ctrl+");
+			itemLabelStr += "\t" + accel;
+		}
+
+		bool isChecked = item.contains("checked") && item["checked"].is_boolean() && item["checked"].get<bool>();
+		GtkWidget *menuItemWidget;
+		if (isChecked || (item.contains("checked") && item["checked"].is_boolean()))
+		{
+			menuItemWidget = gtk_check_menu_item_new_with_label(itemLabelStr.c_str());
+			gtk_check_menu_item_set_active(GTK_CHECK_MENU_ITEM(menuItemWidget), isChecked);
+		}
+		else
+		{
+			menuItemWidget = gtk_menu_item_new_with_label(itemLabelStr.c_str());
+		}
+
+		bool isEnabled = !item.contains("enabled") || !item["enabled"].is_boolean() || item["enabled"].get<bool>();
+		gtk_widget_set_sensitive(menuItemWidget, isEnabled);
+
+		MenuItemData *data = new MenuItemData();
+		data->photino = photino;
+		if (item.contains("command") && item["command"].is_string())
+			data->command = new std::string(item["command"].get<std::string>());
+		else
+			data->command = new std::string("");
+
+		g_object_set_data_full(G_OBJECT(menuItemWidget), "menu-item-data", data, menu_item_data_destroy);
+		g_signal_connect(G_OBJECT(menuItemWidget), "activate",
+						 G_CALLBACK(on_menu_item_activate), data);
+
+		gtk_menu_shell_append(GTK_MENU_SHELL(parentMenu), menuItemWidget);
+	}
+}
+
+void Photino::SetMenu(AutoString menuJson)
+{
+	if (menuJson == NULL || strlen(menuJson) == 0)
+		return;
+
+	try
+	{
+		json menuData = json::parse(menuJson);
+
+		if (!menuData.contains("menus") || !menuData["menus"].is_array())
+			return;
+
+		GtkWidget *menuBar = gtk_menu_bar_new();
+
+		for (auto &menu : menuData["menus"])
+		{
+			if (!menu.contains("label") || !menu["label"].is_string())
+				continue;
+
+			std::string labelStr = menu["label"].get<std::string>();
+			GtkWidget *menuItem = gtk_menu_item_new_with_label(labelStr.c_str());
+			GtkWidget *subMenu = gtk_menu_new();
+			gtk_menu_item_set_submenu(GTK_MENU_ITEM(menuItem), subMenu);
+
+			if (menu.contains("items") && menu["items"].is_array())
+			{
+				BuildMenuItems(subMenu, menu["items"], this);
+			}
+
+			gtk_menu_shell_append(GTK_MENU_SHELL(menuBar), menuItem);
+		}
+
+		GtkWidget *currentChild = gtk_bin_get_child(GTK_BIN(_window));
+
+		if (currentChild == _webview)
+		{
+			g_object_ref(_webview); 
+			gtk_container_remove(GTK_CONTAINER(_window), _webview);
+
+			GtkWidget *vbox = gtk_box_new(GTK_ORIENTATION_VERTICAL, 0);
+			gtk_box_pack_start(GTK_BOX(vbox), menuBar, FALSE, FALSE, 0);
+			gtk_box_pack_start(GTK_BOX(vbox), _webview, TRUE, TRUE, 0);
+			g_object_unref(_webview);
+
+			gtk_container_add(GTK_CONTAINER(_window), vbox);
+			gtk_widget_show_all(vbox);
+		}
+		else if (GTK_IS_BOX(currentChild))
+		{
+			gtk_box_pack_start(GTK_BOX(currentChild), menuBar, FALSE, FALSE, 0);
+			gtk_box_reorder_child(GTK_BOX(currentChild), menuBar, 0);
+			gtk_widget_show_all(menuBar);
+		}
+		else if (currentChild == NULL && _webview == NULL)
+		{
+			GtkWidget *vbox = gtk_box_new(GTK_ORIENTATION_VERTICAL, 0);
+			gtk_box_pack_start(GTK_BOX(vbox), menuBar, FALSE, FALSE, 0);
+			gtk_container_add(GTK_CONTAINER(_window), vbox);
+		}
+	}
+	catch (const std::exception &e)
+	{
+		g_warning("Photino: Failed to parse menu JSON: %s", e.what());
 	}
 }
 

--- a/Photino.Native/Photino.Mac.MenuHandler.h
+++ b/Photino.Native/Photino.Mac.MenuHandler.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#ifdef __APPLE__
+
+#import <Cocoa/Cocoa.h>
+
+class Photino;
+
+@interface MenuActionHandler : NSObject {
+    @public
+    Photino *photino;
+    char *command;
+}
+
+- (void)menuItemClicked:(id)sender;
+- (void)dealloc;
+
+@end
+
+#endif

--- a/Photino.Native/Photino.Mac.mm
+++ b/Photino.Native/Photino.Mac.mm
@@ -7,7 +7,9 @@
 #include "Photino.Mac.UrlSchemeHandler.h"
 #include "Photino.Mac.NSWindowBorderless.h"
 #include "Photino.Mac.NavigationDelegate.h"
+#include "Photino.Mac.MenuHandler.h"
 #include <vector>
+#include <algorithm>
 
 #include "json.hpp"
 
@@ -151,7 +153,8 @@ Photino::Photino(PhotinoInitParams* initParams)
 	_minimizedCallback = (MinimizedCallback)initParams->MinimizedHandler;
 	_restoredCallback = (RestoredCallback)initParams->RestoredHandler;
 	_customSchemeCallback = (WebResourceRequestedCallback)initParams->CustomSchemeHandler;
-    
+    _menuCommandCallback = (MenuCommandCallback)initParams->MenuCommandHandler;
+    _menuHandlers = [[NSMutableArray alloc] init];
 
 	//copy strings from the fixed size array passed, but only if they have a value.
 	for (int i = 0; i < 16; ++i)
@@ -310,6 +313,11 @@ Photino::Photino(PhotinoInitParams* initParams)
     }
 
     _dialog = new PhotinoDialog();
+
+    if (initParams->MenuDefinition != NULL && strlen(initParams->MenuDefinition) > 0)
+    {
+        SetMenu(initParams->MenuDefinition);
+    }
 
     Show(false);
     SetFullScreen(initParams->FullScreen);
@@ -950,4 +958,246 @@ void Photino::Show(bool isAlreadyShown)
     [_window makeKeyAndOrderFront: _window];
     [_window orderFrontRegardless];
 }
+
+@implementation MenuActionHandler
+
+- (void)menuItemClicked:(id)sender
+{
+    if (photino && command)
+    {
+        photino->InvokeMenuCommand(command);
+    }
+}
+
+- (void)dealloc
+{
+    if (command)
+    {
+        free(command);
+        command = NULL;
+    }
+    [super dealloc];
+}
+
+@end
+
+static void ParseAccelerator(const std::string& accelerator, NSString** keyEquivalent, NSEventModifierFlags* modifierMask)
+{
+    *keyEquivalent = @"";
+    *modifierMask = 0;
+
+    if (accelerator.empty())
+        return;
+
+    std::string accel = accelerator;
+
+    if (accel.find("Cmd+") != std::string::npos || accel.find("Command+") != std::string::npos)
+    {
+        *modifierMask |= NSEventModifierFlagCommand;
+        size_t pos = accel.find("Cmd+");
+        if (pos != std::string::npos)
+            accel.erase(pos, 4);
+        pos = accel.find("Command+");
+        if (pos != std::string::npos)
+            accel.erase(pos, 8);
+    }
+
+    if (accel.find("Ctrl+") != std::string::npos || accel.find("Control+") != std::string::npos)
+    {
+        *modifierMask |= NSEventModifierFlagControl;
+        size_t pos = accel.find("Ctrl+");
+        if (pos != std::string::npos)
+            accel.erase(pos, 5);
+        pos = accel.find("Control+");
+        if (pos != std::string::npos)
+            accel.erase(pos, 8);
+    }
+
+    if (accel.find("Alt+") != std::string::npos || accel.find("Option+") != std::string::npos)
+    {
+        *modifierMask |= NSEventModifierFlagOption;
+        size_t pos = accel.find("Alt+");
+        if (pos != std::string::npos)
+            accel.erase(pos, 4);
+        pos = accel.find("Option+");
+        if (pos != std::string::npos)
+            accel.erase(pos, 7);
+    }
+
+    if (accel.find("Shift+") != std::string::npos)
+    {
+        *modifierMask |= NSEventModifierFlagShift;
+        size_t pos = accel.find("Shift+");
+        if (pos != std::string::npos)
+            accel.erase(pos, 6);
+    }
+
+    if (!accel.empty())
+    {
+        std::transform(accel.begin(), accel.end(), accel.begin(), ::tolower);
+        *keyEquivalent = [NSString stringWithUTF8String:accel.c_str()];
+    }
+}
+
+static void BuildMenuItemsMac(NSMenu *parentMenu, const json &items, Photino *photino, NSMutableArray *menuHandlers)
+{
+    for (const auto& item : items)
+    {
+        if (item.contains("type") && item["type"].is_string() && item["type"] == "separator")
+        {
+            [parentMenu addItem:[NSMenuItem separatorItem]];
+            continue;
+        }
+
+        if (!item.contains("label") || !item["label"].is_string())
+            continue;
+
+        NSString *itemLabel = [NSString stringWithUTF8String:item["label"].get<std::string>().c_str()];
+
+        if (item.contains("items") && item["items"].is_array())
+        {
+            NSMenuItem *subMenuItem = [[[NSMenuItem alloc] init] autorelease];
+            [subMenuItem setTitle:itemLabel];
+
+            NSMenu *subMenu = [[[NSMenu alloc] initWithTitle:itemLabel] autorelease];
+
+            BuildMenuItemsMac(subMenu, item["items"], photino, menuHandlers);
+
+            [subMenuItem setSubmenu:subMenu];
+            [parentMenu addItem:subMenuItem];
+            continue;
+        }
+
+        // Regular menu item
+        NSString *keyEquivalent = @"";
+        NSEventModifierFlags modifierMask = 0;
+        if (item.contains("accelerator") && item["accelerator"].is_string())
+        {
+            ParseAccelerator(item["accelerator"].get<std::string>(), &keyEquivalent, &modifierMask);
+        }
+
+        MenuActionHandler *handler = [[MenuActionHandler alloc] init];
+        handler->photino = photino;
+
+        if (item.contains("command") && item["command"].is_string())
+        {
+            char *cmd = strdup(item["command"].get<std::string>().c_str());
+            handler->command = cmd;
+        }
+        else
+        {
+            handler->command = NULL;
+        }
+
+        [menuHandlers addObject:handler];
+
+        NSMenuItem *subItem = [[[NSMenuItem alloc]
+            initWithTitle:itemLabel
+            action:@selector(menuItemClicked:)
+            keyEquivalent:keyEquivalent] autorelease];
+
+        [subItem setTarget:handler];
+        [subItem setKeyEquivalentModifierMask:modifierMask];
+
+        if (item.contains("enabled") && item["enabled"].is_boolean())
+        {
+            [subItem setEnabled:item["enabled"].get<bool>()];
+        }
+
+        if (item.contains("checked") && item["checked"].is_boolean() && item["checked"].get<bool>())
+        {
+            [subItem setState:NSControlStateValueOn];
+        }
+
+        [parentMenu addItem:subItem];
+    }
+}
+
+void Photino::SetMenu(AutoString menuJson)
+{
+    if (menuJson == NULL || strlen(menuJson) == 0)
+        return;
+
+    try
+    {
+        json menuData = json::parse(menuJson);
+
+        if (!menuData.contains("menus") || !menuData["menus"].is_array())
+            return;
+
+        for (id handler in _menuHandlers)
+        {
+            [handler release];
+        }
+        [_menuHandlers removeAllObjects];
+
+        NSMenu *mainMenu = [[[NSMenu alloc] init] autorelease];
+
+        NSString *appName = [[NSProcessInfo processInfo] processName];
+        NSMenuItem *appMenuItem = [[[NSMenuItem alloc] init] autorelease];
+        NSMenu *appMenu = [[[NSMenu alloc] init] autorelease];
+
+        NSMenuItem *selectAllItem = [[[NSMenuItem alloc]
+            initWithTitle:@"Select All"
+            action:@selector(selectAll:)
+            keyEquivalent:@"a"] autorelease];
+        [appMenu addItem:selectAllItem];
+
+        NSMenuItem *cutItem = [[[NSMenuItem alloc]
+            initWithTitle:@"Cut"
+            action:@selector(cut:)
+            keyEquivalent:@"x"] autorelease];
+        [appMenu addItem:cutItem];
+
+        NSMenuItem *copyItem = [[[NSMenuItem alloc]
+            initWithTitle:@"Copy"
+            action:@selector(copy:)
+            keyEquivalent:@"c"] autorelease];
+        [appMenu addItem:copyItem];
+
+        NSMenuItem *pasteItem = [[[NSMenuItem alloc]
+            initWithTitle:@"Paste"
+            action:@selector(paste:)
+            keyEquivalent:@"v"] autorelease];
+        [appMenu addItem:pasteItem];
+
+        [appMenu addItem:[NSMenuItem separatorItem]];
+
+        NSMenuItem *quitItem = [[[NSMenuItem alloc]
+            initWithTitle:[NSString stringWithFormat:@"Quit %@", appName]
+            action:@selector(terminate:)
+            keyEquivalent:@"q"] autorelease];
+        [appMenu addItem:quitItem];
+
+        [appMenuItem setSubmenu:appMenu];
+        [mainMenu addItem:appMenuItem];
+
+        for (auto& menu : menuData["menus"])
+        {
+            if (!menu.contains("label") || !menu["label"].is_string())
+                continue;
+
+            NSString *menuLabel = [NSString stringWithUTF8String:menu["label"].get<std::string>().c_str()];
+            NSMenuItem *menuItem = [[[NSMenuItem alloc] init] autorelease];
+            [menuItem setTitle:menuLabel];
+
+            NSMenu *subMenu = [[[NSMenu alloc] initWithTitle:menuLabel] autorelease];
+
+            if (menu.contains("items") && menu["items"].is_array())
+            {
+                BuildMenuItemsMac(subMenu, menu["items"], this, _menuHandlers);
+            }
+
+            [menuItem setSubmenu:subMenu];
+            [mainMenu addItem:menuItem];
+        }
+
+        [NSApp setMainMenu:mainMenu];
+    }
+    catch (const std::exception& e)
+    {
+        NSLog(@"Photino: Failed to parse menu JSON: %s", e.what());
+    }
+}
+
 #endif

--- a/Photino.Native/Photino.Windows.cpp
+++ b/Photino.Native/Photino.Windows.cpp
@@ -2,6 +2,7 @@
 #include "Photino.Dialog.h"
 #include "Photino.Windows.DarkMode.h"
 #include "Photino.Windows.ToastHandler.h"
+#include "json.hpp"
 
 #include <mutex>
 #include <condition_variable>
@@ -13,6 +14,8 @@
 #include <limits>
 #include <WebView2EnvironmentOptions.h>
 #include <Shellscalingapi.h>
+
+using json = nlohmann::json;
 
 #pragma comment(lib, "Shcore.lib")
 #pragma comment(lib, "Urlmon.lib")
@@ -197,6 +200,10 @@ Photino::Photino(PhotinoInitParams* initParams)
 	_focusInCallback = (FocusInCallback)initParams->FocusInHandler;
 	_focusOutCallback = (FocusOutCallback)initParams->FocusOutHandler;
 	_customSchemeCallback = (WebResourceRequestedCallback)initParams->CustomSchemeHandler;
+	_menuCommandCallback = (MenuCommandCallback)initParams->MenuCommandHandler;
+
+	_hMenu = NULL;
+	_nextMenuId = 1000;
 
 	//copy strings from the fixed size array passed, but only if they have a value.
 	for (int i = 0; i < 16; ++i)
@@ -308,6 +315,11 @@ Photino::Photino(PhotinoInitParams* initParams)
 
 	_dialog = new PhotinoDialog(this);
 
+	if (initParams->MenuDefinition != NULL && wcslen(initParams->MenuDefinition) > 0)
+	{
+		SetMenu(initParams->MenuDefinition);
+	}
+
 	bool isAlreadyShown = initParams->Minimized || initParams->Maximized;
 	Photino::Show(isAlreadyShown);
 }
@@ -319,6 +331,7 @@ Photino::~Photino()
 	if (_temporaryFilesPath != NULL) delete[]_temporaryFilesPath;
 	if (_windowTitle != NULL) delete[]_windowTitle;
 	if (_notificationsEnabled && _toastHandler != NULL) delete _toastHandler;
+	if (_hMenu != NULL) DestroyMenu(_hMenu);
 }
 
 HWND Photino::getHwnd()
@@ -452,6 +465,17 @@ LRESULT CALLBACK WindowProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
 		}
 		waitInfo->completionNotifier.notify_one();
 		//delete waitInfo; ?
+		return 0;
+	}
+	case WM_COMMAND:
+	{
+		UINT menuId = LOWORD(wParam);
+		Photino* photino = hwndToPhotino[hwnd];
+		if (photino && photino->_menuCommands.count(menuId))
+		{
+			std::string command = photino->_menuCommands[menuId];
+			photino->InvokeMenuCommand(photino->ToUTF16String((AutoString)command.c_str()));
+		}
 		return 0;
 	}
 	case WM_GETMINMAXINFO:
@@ -1352,5 +1376,119 @@ void Photino::Show(bool isAlreadyShown)
 			Photino::AttachWebView();
 		else
 			exit(0);
+	}
+}
+
+static void BuildMenuItemsWin(HMENU parentMenu, const json &items, Photino *photino,
+                              std::map<UINT, std::string> &menuCommands, UINT &nextMenuId)
+{
+	for (const auto& item : items)
+	{
+		if (item.contains("type") && item["type"] == "separator")
+		{
+			AppendMenuW(parentMenu, MF_SEPARATOR, 0, NULL);
+			continue;
+		}
+
+		if (!item.contains("label") || !item["label"].is_string())
+			continue;
+
+		std::string itemLabelStr = item["label"].get<std::string>();
+		std::wstring itemText = (wchar_t*)photino->ToUTF16String((AutoString)itemLabelStr.c_str());
+
+		if (item.contains("items") && item["items"].is_array())
+		{
+			HMENU hSubMenu = CreatePopupMenu();
+
+			BuildMenuItemsWin(hSubMenu, item["items"], photino, menuCommands, nextMenuId);
+
+			AppendMenuW(parentMenu, MF_POPUP, (UINT_PTR)hSubMenu, itemText.c_str());
+			continue;
+		}
+
+		if (item.contains("accelerator"))
+		{
+			std::string accel = item["accelerator"].get<std::string>();
+			std::string displayAccel = accel;
+			size_t pos;
+			while ((pos = displayAccel.find("Cmd+")) != std::string::npos)
+				displayAccel.replace(pos, 4, "Ctrl+");
+
+			itemText += L"\t";
+			itemText += (wchar_t*)photino->ToUTF16String((AutoString)displayAccel.c_str());
+		}
+
+		std::string command = "";
+		if (item.contains("command") && item["command"].is_string())
+			command = item["command"].get<std::string>();
+
+		UINT menuId = nextMenuId++;
+		menuCommands[menuId] = command;
+
+		UINT menuFlags = MF_STRING;
+
+		if (item.contains("enabled") && item["enabled"].is_boolean() && !item["enabled"].get<bool>())
+		{
+			menuFlags |= MF_GRAYED;
+		}
+
+		if (item.contains("checked") && item["checked"].is_boolean() && item["checked"].get<bool>())
+		{
+			menuFlags |= MF_CHECKED;
+		}
+
+		AppendMenuW(parentMenu, menuFlags, menuId, itemText.c_str());
+	}
+}
+
+void Photino::SetMenu(AutoString menuJson)
+{
+	if (menuJson == NULL || wcslen(menuJson) == 0)
+		return;
+
+	try
+	{
+		std::string jsonStr = ToUTF8String(menuJson);
+		json menuData = json::parse(jsonStr);
+
+		if (!menuData.contains("menus") || !menuData["menus"].is_array())
+			return;
+
+		if (_hMenu != NULL)
+		{
+			DestroyMenu(_hMenu);
+			_hMenu = NULL;
+		}
+
+		_hMenu = CreateMenu();
+		_menuCommands.clear();
+		_nextMenuId = 1000;
+
+		for (auto& menu : menuData["menus"])
+		{
+			if (!menu.contains("label") || !menu["label"].is_string())
+				continue;
+
+			std::string labelStr = menu["label"].get<std::string>();
+			std::wstring label = (wchar_t*)ToUTF16String((AutoString)labelStr.c_str());
+
+			HMENU hSubMenu = CreatePopupMenu();
+
+			if (menu.contains("items") && menu["items"].is_array())
+			{
+				BuildMenuItemsWin(hSubMenu, menu["items"], this, _menuCommands, _nextMenuId);
+			}
+
+			AppendMenuW(_hMenu, MF_POPUP, (UINT_PTR)hSubMenu, label.c_str());
+		}
+
+		::SetMenu(_hWnd, _hMenu);
+		DrawMenuBar(_hWnd);
+	}
+	catch (const std::exception& e)
+	{
+		OutputDebugStringA("Photino: Failed to parse menu JSON: ");
+		OutputDebugStringA(e.what());
+		OutputDebugStringA("\n");
 	}
 }

--- a/Photino.Native/Photino.h
+++ b/Photino.Native/Photino.h
@@ -52,6 +52,7 @@ typedef void (*MovedCallback)(int x, int y);
 typedef bool (*ClosingCallback)();
 typedef void (*FocusInCallback)();
 typedef void (*FocusOutCallback)();
+typedef void (*MenuCommandCallback)(AutoString command);
 
 class PhotinoDialog;
 class Photino;
@@ -80,6 +81,9 @@ struct PhotinoInitParams
 	WebMessageReceivedCallback *WebMessageReceivedHandler;
 	AutoString CustomSchemeNames[16];
 	WebResourceRequestedCallback *CustomSchemeHandler;
+
+	AutoString MenuDefinition;
+	MenuCommandCallback *MenuCommandHandler;
 
 	int Left;
 	int Top;
@@ -131,6 +135,7 @@ private:
 	FocusOutCallback _focusOutCallback;
 	std::vector<AutoString> _customSchemeNames;
 	WebResourceRequestedCallback _customSchemeCallback;
+	MenuCommandCallback _menuCommandCallback;
 
 	AutoString _startUrl;
 	AutoString _startString;
@@ -161,6 +166,9 @@ private:
 #ifdef _WIN32
 	static HINSTANCE _hInstance;
 	HWND _hWnd;
+	HMENU _hMenu;
+	std::map<UINT, std::string> _menuCommands;
+	UINT _nextMenuId;
 	WinToastHandler *_toastHandler;
 	wil::com_ptr<ICoreWebView2Environment> _webviewEnvironment;
 	wil::com_ptr<ICoreWebView2> _webviewWindow;
@@ -180,6 +188,7 @@ private:
 	NSWindow *_window;
 	WKWebView *_webview;
 	WKWebViewConfiguration *_webviewConfiguration;
+	NSMutableArray *_menuHandlers;
 	std::vector<Monitor *> GetMonitors();
 	
 	bool _chromeless;
@@ -310,6 +319,14 @@ public:
 	void SetMaximizedCallback(MaximizedCallback callback) { _maximizedCallback = callback; }
 	void SetRestoredCallback(RestoredCallback callback) { _restoredCallback = callback; }
 	void SetMinimizedCallback(MinimizedCallback callback) { _minimizedCallback = callback; }
+
+	void SetMenu(AutoString menuJson);
+	void SetMenuCommandCallback(MenuCommandCallback callback) { _menuCommandCallback = callback; }
+	void InvokeMenuCommand(AutoString command)
+	{
+		if (_menuCommandCallback)
+			_menuCommandCallback(command);
+	}
 
 	void Invoke(ACTION callback);
 	bool InvokeClose()


### PR DESCRIPTION
I know there's some history to this, but it looked like there hadn't been progress in a while and wanted to see this one happen. I tried to take notes from those conversation threads here in the initial implementation. Not everything was of equal complexity, so I'm hoping maybe this is something that could be supported in phases once we get a core in? 

Let me know what you think or if there's anything I could do to help get this implemented. Appreciate the effort you guys put in on this, I've ended up using Photino Blazor heavily for my desktop apps!

Full disclosure I only tested this on Mac so far which is why I'm opening it in draft. I followed patterns for windows/linux so hopefully the testing there goes well. 

Adds initial support for native menu handling across platforms
 - Uses suggested JSON approach
 - Adds supports for native menus in macOS, windows, linux
 - Supports submenus, accelerators, disabled, and checked states

Not supported yet:
 - Icons
 - Updating menus after creation/dynamically creating menus
 - Context menus

 Closes: #42, #43, #44