### PR TITLE
Fix topmost style register on Windows, add null checks on Linux

### DIFF
--- a/Photino.Native/Photino.Linux.cpp
+++ b/Photino.Native/Photino.Linux.cpp
@@ -410,6 +410,11 @@ void Photino::GetMaximized(bool *isMaximized)
 	//gboolean maximized = gtk_window_is_maximized(GTK_WINDOW(_window));  //this method doesn't work
 	//*isMaximized = maximized;
 	GdkWindow *gdk_window = gtk_widget_get_window(GTK_WIDGET(_window));
+	if (gdk_window == NULL)
+	{
+		*isMaximized = false;
+		return;
+	}
 	GdkWindowState flags = gdk_window_get_state(gdk_window);
 	*isMaximized = flags & GDK_WINDOW_STATE_MAXIMIZED;
 }
@@ -417,6 +422,11 @@ void Photino::GetMaximized(bool *isMaximized)
 void Photino::GetMinimized(bool *isMinimized)
 {
 	GdkWindow *gdk_window = gtk_widget_get_window(GTK_WIDGET(_window));
+	if (gdk_window == NULL)
+	{
+		*isMinimized = false;
+		return;
+	}
 	GdkWindowState flags = gdk_window_get_state(gdk_window);
 	*isMinimized = flags & GDK_WINDOW_STATE_ICONIFIED;
 }
@@ -468,6 +478,11 @@ void Photino::GetTopmost(bool *topmost)
 {
 	// TODO: This flag is not set in GDK3. WebKit does not support GTK5 yet.
 	GdkWindow *gdk_window = gtk_widget_get_window(GTK_WIDGET(_window));
+	if (gdk_window == NULL)
+	{
+		*topmost = false;
+		return;
+	}
 	GdkWindowState flags = gdk_window_get_state(gdk_window);
 	*topmost = flags & GDK_WINDOW_STATE_ABOVE;
 

--- a/Photino.Native/Photino.Windows.cpp
+++ b/Photino.Native/Photino.Windows.cpp
@@ -661,7 +661,7 @@ AutoString Photino::GetTitle()
 
 void Photino::GetTopmost(bool* topmost)
 {
-	LONG lStyles = GetWindowLong(_hWnd, GWL_STYLE);
+	LONG lStyles = GetWindowLong(_hWnd, GWL_EXSTYLE);
 	if (lStyles & WS_EX_TOPMOST) *topmost = true;
 	else *topmost = false;
 }
@@ -841,10 +841,10 @@ void Photino::SetTitle(AutoString title)
 
 void Photino::SetTopmost(bool topmost)
 {
-	LONG_PTR style = GetWindowLongPtr(_hWnd, GWL_STYLE);
+	LONG_PTR style = GetWindowLongPtr(_hWnd, GWL_EXSTYLE);
 	if (topmost) style |= WS_EX_TOPMOST;
 	else style &= (~WS_EX_TOPMOST);
-	SetWindowLongPtr(_hWnd, GWL_STYLE, style);
+	SetWindowLongPtr(_hWnd, GWL_EXSTYLE, style);
 	SetWindowPos(_hWnd, topmost ? HWND_TOPMOST : HWND_NOTOPMOST, 0, 0, 0, 0, SWP_NOMOVE | SWP_NOSIZE);
 }
 


### PR DESCRIPTION
## Summary

- **Windows:** Fix `SetTopmost` and `GetTopmost` to use `GWL_EXSTYLE` instead of `GWL_STYLE` when reading and writing `WS_EX_TOPMOST`, which is an extended window style.
- **Linux:** Add null guards for `gtk_widget_get_window()` in `GetTopmost`, `GetMaximized`, and `GetMinimized` to prevent a SIGSEGV when the widget has not yet been realized.

Fixes #175

## Windows: fix extended style register in SetTopmost/GetTopmost

`WS_EX_TOPMOST` is an extended window style, but `SetTopmost` and `GetTopmost` were accessing it through `GWL_STYLE` (the regular style register). This meant the topmost flag was never actually read or written correctly. The fix changes `GWL_STYLE` to `GWL_EXSTYLE` in all three affected call sites (`GetWindowLongPtr` in `GetTopmost`, and `GetWindowLongPtr`/`SetWindowLongPtr` in `SetTopmost`). The `SetWindowLongPtr` write is retained so that the extended style register stays in sync with the actual window state set by `SetWindowPos`, consistent with how all other style-modifying functions in the file are structured.

## Linux: add null checks in GetTopmost, GetMaximized, GetMinimized

`gtk_widget_get_window()` returns `NULL` before the widget is realized. All three getters passed the result directly to `gdk_window_get_state()` without checking for null, which caused a segmentation fault if called too early in the widget lifecycle. The fix adds a null check in each function, returning `false` as a safe default when the underlying GDK window is not yet available.

## Alternatives considered

- **Remove the `SetWindowLongPtr` call entirely.** `WS_EX_TOPMOST` cannot actually be toggled via `SetWindowLongPtr` after window creation; only `SetWindowPos` with `HWND_TOPMOST`/`HWND_NOTOPMOST` can do that. I kept the write anyway because every other style function in the file follows the same read-modify-write-apply pattern (`SetResizable`, `SetFullScreen`, etc.), and removing it would make `SetTopmost` an unexplained outlier.
- **Reorder the calls** to execute `SetWindowPos` first and then sync the register afterward. This would break the established pattern in the file without a clear practical benefit, so I opted for the minimal fix of correcting the register constant.