### PR TITLE
feat(linux): Export native GtkWidget pointer for Linux platform

### DIFF
--- a/Photino.Native/Exports.cpp
+++ b/Photino.Native/Exports.cpp
@@ -34,6 +34,11 @@ extern "C"
 	{
 		Photino::Register();
 	}
+#elif __linux__
+	EXPORTED void* Photino_getGtkWindow_linux(Photino* instance)
+	{
+		return instance->_window;
+	}
 #endif
 
 	EXPORTED Photino* Photino_ctor(PhotinoInitParams* initParams)


### PR DESCRIPTION
This PR exports the native `GtkWidget* _window` pointer for the Linux platform in `Exports.cpp`.

Currently, getting the window handle on Linux throws a `NotSupportedException` in the .NET wrapper. Exporting this pointer allows developers to access the underlying GtkWindow to perform OS-specific window manipulations (like X11/Wayland specific configurations, transparency hints, etc.) directly from C# without relying on workarounds like iterating over GTK toplevel lists.

- Compiled successfully on Fedora Workstation using `WebKit2GTK` and `.NET 9`.
- Verified that the exported pointer correctly returns the GTK Window ID/Handle and is accessible via `[LibraryImport]` in the .NET wrapper.