### PR TITLE
Add native script execution and popup callbacks

### DIFF
--- a/Photino.Native/Exports.cpp
+++ b/Photino.Native/Exports.cpp
@@ -181,6 +181,11 @@ extern "C"
 		instance->NavigateToUrl(url);
 	}
 
+	EXPORTED bool Photino_ExecuteScript(Photino* instance, AutoString script)
+	{
+		return instance && instance->ExecuteScript(script);
+	}
+
 	EXPORTED void Photino_Restore(Photino* instance)
 	{
 		instance->Restore();

--- a/Photino.Native/Photino.Linux.cpp
+++ b/Photino.Native/Photino.Linux.cpp
@@ -506,6 +506,15 @@ void Photino::NavigateToUrl(AutoString url)
 	webkit_web_view_load_uri(WEBKIT_WEB_VIEW(_webview), url);
 }
 
+bool Photino::ExecuteScript(AutoString script)
+{
+	if (!_webview)
+		return false;
+
+	webkit_web_view_run_javascript(WEBKIT_WEB_VIEW(_webview), script, NULL, NULL, NULL);
+	return true;
+}
+
 void Photino::Restore()
 {
 	gtk_window_present(GTK_WINDOW(_window));

--- a/Photino.Native/Photino.Linux.cpp
+++ b/Photino.Native/Photino.Linux.cpp
@@ -150,6 +150,7 @@ Photino::Photino(PhotinoInitParams *initParams) : _webview(nullptr)
 	_maximizedCallback = (MaximizedCallback)initParams->MaximizedHandler;
 	_minimizedCallback = (MinimizedCallback)initParams->MinimizedHandler;
 	_restoredCallback = (RestoredCallback)initParams->RestoredHandler;
+	_popupRequestedCallback = (PopupRequestedCallback)initParams->PopupRequestedHandler;
 	_customSchemeCallback = (WebResourceRequestedCallback)initParams->CustomSchemeHandler;
 
 	// copy strings from the fixed size array passed, but only if they have a value.
@@ -786,6 +787,18 @@ void HandleWebMessage(WebKitUserContentManager *contentManager, WebKitJavascript
 	webkit_javascript_result_unref(jsResult);
 }
 
+WebKitWebView *HandleCreateWebView(WebKitWebView *webView, WebKitNavigationAction *navigationAction, gpointer arg)
+{
+	Photino *photino = (Photino *)arg;
+	WebKitURIRequest *request = webkit_navigation_action_get_request(navigationAction);
+	const gchar *uri = request ? webkit_uri_request_get_uri(request) : "";
+
+	if (photino && photino->InvokePopupRequested((AutoString)uri, (AutoString)"", -1, -1, -1, -1))
+		return NULL;
+
+	return NULL;
+}
+
 void Photino::Show(bool isAlreadyShown)
 {
 	if (!_webview)
@@ -822,6 +835,7 @@ void Photino::Show(bool isAlreadyShown)
 		g_signal_connect(contentManager, "script-message-received::Photinointerop",
 						 G_CALLBACK(HandleWebMessage), (void *)_webMessageReceivedCallback);
 		webkit_user_content_manager_register_script_message_handler(contentManager, "Photinointerop");
+		g_signal_connect(_webview, "create", G_CALLBACK(HandleCreateWebView), this);
 
 		if (_startUrl != NULL)
 			Photino::NavigateToUrl(_startUrl);

--- a/Photino.Native/Photino.Mac.UiDelegate.h
+++ b/Photino.Native/Photino.Mac.UiDelegate.h
@@ -7,6 +7,7 @@
     NSWindow * window;
     Photino * photino;
     WebMessageReceivedCallback webMessageReceivedCallback;
+    PopupRequestedCallback popupRequestedCallback;
 }
 @end
 #endif

--- a/Photino.Native/Photino.Mac.UiDelegate.mm
+++ b/Photino.Native/Photino.Mac.UiDelegate.mm
@@ -96,6 +96,23 @@
     photino->GetGrantBrowserPermissions(&grantPermissions);
     decisionHandler(grantPermissions ? WKPermissionDecisionGrant : WKPermissionDecisionPrompt);
 }
+
+- (WKWebView *)webView:(WKWebView *)webView
+        createWebViewWithConfiguration:(WKWebViewConfiguration *)configuration
+        forNavigationAction:(WKNavigationAction *)navigationAction
+        windowFeatures:(WKWindowFeatures *)windowFeatures
+{
+    NSString *url = navigationAction.request.URL.absoluteString ?: @"";
+    int x = windowFeatures.x ? [windowFeatures.x intValue] : -1;
+    int y = windowFeatures.y ? [windowFeatures.y intValue] : -1;
+    int width = windowFeatures.width ? [windowFeatures.width intValue] : -1;
+    int height = windowFeatures.height ? [windowFeatures.height intValue] : -1;
+
+    if (popupRequestedCallback && popupRequestedCallback((char *)[url UTF8String], (char *)"", x, y, width, height))
+        return nil;
+
+    return nil;
+}
 @end
 
 #endif

--- a/Photino.Native/Photino.Mac.mm
+++ b/Photino.Native/Photino.Mac.mm
@@ -499,6 +499,15 @@ void Photino::NavigateToUrl(AutoString url)
     [_webview loadRequest: nsrequest];
 }
 
+bool Photino::ExecuteScript(AutoString script)
+{
+    if (!_webview)
+        return false;
+
+    [_webview evaluateJavaScript: [NSString stringWithUTF8String: script] completionHandler: nil];
+    return true;
+}
+
 void Photino::Restore()
 {
     bool minimized;

--- a/Photino.Native/Photino.Mac.mm
+++ b/Photino.Native/Photino.Mac.mm
@@ -149,6 +149,7 @@ Photino::Photino(PhotinoInitParams* initParams)
     _maximizedCallback = (MaximizedCallback)initParams->MaximizedHandler;
 	_minimizedCallback = (MinimizedCallback)initParams->MinimizedHandler;
 	_restoredCallback = (RestoredCallback)initParams->RestoredHandler;
+    _popupRequestedCallback = (PopupRequestedCallback)initParams->PopupRequestedHandler;
 	_customSchemeCallback = (WebResourceRequestedCallback)initParams->CustomSchemeHandler;
     
 
@@ -916,6 +917,7 @@ void Photino::AttachWebView()
     uiDelegate->photino = this;
     uiDelegate->window = _window;
     uiDelegate->webMessageReceivedCallback = _webMessageReceivedCallback;
+    uiDelegate->popupRequestedCallback = _popupRequestedCallback;
 
     NavigationDelegate *navDelegate = [[[NavigationDelegate alloc] init] autorelease];
     navDelegate->photino = this;

--- a/Photino.Native/Photino.Windows.cpp
+++ b/Photino.Native/Photino.Windows.cpp
@@ -195,6 +195,7 @@ Photino::Photino(PhotinoInitParams* initParams)
 	_closingCallback = (ClosingCallback)initParams->ClosingHandler;
 	_focusInCallback = (FocusInCallback)initParams->FocusInHandler;
 	_focusOutCallback = (FocusOutCallback)initParams->FocusOutHandler;
+	_popupRequestedCallback = (PopupRequestedCallback)initParams->PopupRequestedHandler;
 	_customSchemeCallback = (WebResourceRequestedCallback)initParams->CustomSchemeHandler;
 
 	//copy strings from the fixed size array passed, but only if they have a value.
@@ -1056,6 +1057,55 @@ void Photino::AttachWebView()
 								_webMessageReceivedCallback(message.get());
 								return S_OK;
 							}).Get(), &webMessageToken);
+
+						EventRegistrationToken newWindowToken;
+						_webviewWindow->add_NewWindowRequested(Callback<ICoreWebView2NewWindowRequestedEventHandler>(
+							[&](ICoreWebView2* sender, ICoreWebView2NewWindowRequestedEventArgs* args) -> HRESULT {
+								wil::unique_cotaskmem_string uri;
+								args->get_Uri(&uri);
+
+								wil::unique_cotaskmem_string name;
+								auto args2 = wil::com_ptr<ICoreWebView2NewWindowRequestedEventArgs>(args).try_query<ICoreWebView2NewWindowRequestedEventArgs2>();
+								if (args2)
+									args2->get_Name(&name);
+
+								int x = -1;
+								int y = -1;
+								int width = -1;
+								int height = -1;
+
+								wil::com_ptr<ICoreWebView2WindowFeatures> features;
+								args->get_WindowFeatures(&features);
+								if (features)
+								{
+									BOOL hasPosition = FALSE;
+									if (SUCCEEDED(features->get_HasPosition(&hasPosition)) && hasPosition)
+									{
+										UINT32 left = 0;
+										UINT32 top = 0;
+										features->get_Left(&left);
+										features->get_Top(&top);
+										x = (int)left;
+										y = (int)top;
+									}
+
+									BOOL hasSize = FALSE;
+									if (SUCCEEDED(features->get_HasSize(&hasSize)) && hasSize)
+									{
+										UINT32 featureWidth = 0;
+										UINT32 featureHeight = 0;
+										features->get_Width(&featureWidth);
+										features->get_Height(&featureHeight);
+										width = (int)featureWidth;
+										height = (int)featureHeight;
+									}
+								}
+
+								if (InvokePopupRequested(uri.get(), name.get(), x, y, width, height))
+									args->put_Handled(TRUE);
+
+								return S_OK;
+							}).Get(), &newWindowToken);
 
 						EventRegistrationToken webResourceRequestedToken;
 						_webviewWindow->AddWebResourceRequestedFilter(L"*", COREWEBVIEW2_WEB_RESOURCE_CONTEXT_ALL);

--- a/Photino.Native/Photino.Windows.cpp
+++ b/Photino.Native/Photino.Windows.cpp
@@ -688,6 +688,19 @@ void Photino::NavigateToUrl(AutoString url)
 	_webviewWindow->Navigate(url);
 }
 
+bool Photino::ExecuteScript(AutoString script)
+{
+	if (!_webviewWindow)
+		return false;
+
+	script = ToUTF16String(script);
+	return SUCCEEDED(_webviewWindow->ExecuteScript(script, Callback<ICoreWebView2ExecuteScriptCompletedHandler>(
+		[](HRESULT errorCode, LPCWSTR resultObjectAsJson) -> HRESULT
+		{
+			return S_OK;
+		}).Get()));
+}
+
 void Photino::Restore()
 {
 	ShowWindow(_hWnd, SW_RESTORE);

--- a/Photino.Native/Photino.h
+++ b/Photino.Native/Photino.h
@@ -52,6 +52,7 @@ typedef void (*MovedCallback)(int x, int y);
 typedef bool (*ClosingCallback)();
 typedef void (*FocusInCallback)();
 typedef void (*FocusOutCallback)();
+typedef bool (*PopupRequestedCallback)(AutoString url, AutoString name, int x, int y, int width, int height);
 
 class PhotinoDialog;
 class Photino;
@@ -78,6 +79,7 @@ struct PhotinoInitParams
 	MinimizedCallback *MinimizedHandler;
 	MovedCallback *MovedHandler;
 	WebMessageReceivedCallback *WebMessageReceivedHandler;
+	PopupRequestedCallback *PopupRequestedHandler;
 	AutoString CustomSchemeNames[16];
 	WebResourceRequestedCallback *CustomSchemeHandler;
 
@@ -128,6 +130,7 @@ private:
 	ClosingCallback _closingCallback;
 	FocusInCallback _focusInCallback;
 	FocusOutCallback _focusOutCallback;
+	PopupRequestedCallback _popupRequestedCallback;
 	std::vector<AutoString> _customSchemeNames;
 	WebResourceRequestedCallback _customSchemeCallback;
 
@@ -273,6 +276,10 @@ public:
 	void NavigateToString(AutoString content);
 	void NavigateToUrl(AutoString url);
 	bool ExecuteScript(AutoString script);
+	bool InvokePopupRequested(AutoString url, AutoString name, int x, int y, int width, int height)
+	{
+		return _popupRequestedCallback && _popupRequestedCallback(url, name, x, y, width, height);
+	}
 	void Restore(); // required anymore?backward compat?
 	void SendWebMessage(AutoString message);
 

--- a/Photino.Native/Photino.h
+++ b/Photino.Native/Photino.h
@@ -272,6 +272,7 @@ public:
 
 	void NavigateToString(AutoString content);
 	void NavigateToUrl(AutoString url);
+	bool ExecuteScript(AutoString script);
 	void Restore(); // required anymore?backward compat?
 	void SendWebMessage(AutoString message);
 

--- a/Photino.Test/Photino.Test.csproj
+++ b/Photino.Test/Photino.Test.csproj
@@ -37,6 +37,7 @@
     <Compile Include="..\..\photino.NET\Photino.NET\PhotinoNetDelegates.cs" Link="PhotinoNetDelegates.cs" />
     <Compile Include="..\..\photino.NET\Photino.NET\PhotinoScriptExecution.cs" Link="PhotinoScriptExecution.cs" />
     <Compile Include="..\..\photino.NET\Photino.NET\PhotinoWindow.NET.cs" Link="PhotinoWindow.NET.cs" />
+    <Compile Include="..\..\photino.NET\Photino.NET\PopupRequestedEventArgs.cs" Link="PopupRequestedEventArgs.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Photino.Test/Photino.Test.csproj
+++ b/Photino.Test/Photino.Test.csproj
@@ -35,6 +35,7 @@
     <Compile Include="..\..\photino.NET\Photino.NET\PhotinoNativeDelegates.cs" Link="PhotinoNativeDelegates.cs" />
     <Compile Include="..\..\photino.NET\Photino.NET\PhotinoNativeParameters.cs" Link="PhotinoNativeParameters.cs" />
     <Compile Include="..\..\photino.NET\Photino.NET\PhotinoNetDelegates.cs" Link="PhotinoNetDelegates.cs" />
+    <Compile Include="..\..\photino.NET\Photino.NET\PhotinoScriptExecution.cs" Link="PhotinoScriptExecution.cs" />
     <Compile Include="..\..\photino.NET\Photino.NET\PhotinoWindow.NET.cs" Link="PhotinoWindow.NET.cs" />
   </ItemGroup>
 


### PR DESCRIPTION
## Summary

Adds native browser integration for two managed features:

- a Photino_ExecuteScript export for executing JavaScript in the hosted browser control
- a popup-request callback for browser new-window requests such as window.open(...) and target=_blank

Popup callback data includes URL, target name when available, and requested bounds when supplied by the browser engine. The callback return value lets the managed layer suppress the browser engine's default popup handling.

Implemented for:
- Windows/WebView2 via ICoreWebView2::ExecuteScript and NewWindowRequested
- Linux/WebKitGTK via webkit_web_view_run_javascript and the create signal
- macOS/WKWebView via evaluateJavaScript and createWebViewWithConfiguration

The script execution native method returns false when the browser control is not ready yet, allowing the managed wrapper to fail safely instead of crashing or hanging.

## Paired PR

Pairs with tryphotino/photino.NET#276, which exposes ExecuteScript, ExecuteScriptAsync, and PopupRequested from Photino.NET.

## Validation

- MSBuild Photino.Native/Photino.Native.vcxproj /p:Configuration=Debug /p:Platform=x64 /p:PlatformToolset=v145
- dotnet build Photino.Test/Photino.Test.csproj /p:Platform=x64
- Manual Windows smoke test through Photino.NET and BrowserMcp using the local native DLL
- Manual Windows smoke test for PopupRequested with window.open(...), URL/name/bounds, and Handled=true
