### PR TITLE
Wire input dialog callbacks

### DIFF
--- a/Photino.Native/Exports.cpp
+++ b/Photino.Native/Exports.cpp
@@ -201,6 +201,11 @@ extern "C"
 		instance->SetContextMenuEnabled(enabled);
 	}
 
+	EXPORTED void Photino_SetInputDialogInterceptionEnabled(Photino* instance, bool enabled)
+	{
+		instance->SetInputDialogInterceptionEnabled(enabled);
+	}
+
 	EXPORTED void Photino_SetDevToolsEnabled(Photino* instance, bool enabled)
 	{
 		instance->SetDevToolsEnabled(enabled);

--- a/Photino.Native/Photino.Linux.cpp
+++ b/Photino.Native/Photino.Linux.cpp
@@ -152,6 +152,7 @@ Photino::Photino(PhotinoInitParams *initParams) : _webview(nullptr)
 	_minimizedCallback = (MinimizedCallback)initParams->MinimizedHandler;
 	_restoredCallback = (RestoredCallback)initParams->RestoredHandler;
 	_inputDialogRequestedCallback = (InputDialogRequestedCallback)initParams->InputDialogRequestedHandler;
+	_inputDialogInterceptionEnabled = false;
 	_customSchemeCallback = (WebResourceRequestedCallback)initParams->CustomSchemeHandler;
 
 	// copy strings from the fixed size array passed, but only if they have a value.
@@ -568,7 +569,7 @@ const int InputDialogResponseLength = 32768;
 gboolean HandleScriptDialog(WebKitWebView *webView, WebKitScriptDialog *dialog, gpointer arg)
 {
 	Photino *photino = (Photino *)arg;
-	if (!photino)
+	if (!photino || !photino->GetInputDialogInterceptionEnabled())
 		return FALSE;
 
 	int kind;
@@ -646,6 +647,11 @@ void Photino::SetDevToolsEnabled(bool enabled)
 	_devToolsEnabled = enabled;
 	WebKitSettings *settings = webkit_web_view_get_settings(WEBKIT_WEB_VIEW(_webview));
 	webkit_settings_set_enable_developer_extras(settings, _devToolsEnabled);
+}
+
+void Photino::SetInputDialogInterceptionEnabled(bool enabled)
+{
+	_inputDialogInterceptionEnabled = enabled;
 }
 
 void Photino::SetFullScreen(bool fullScreen)

--- a/Photino.Native/Photino.Linux.cpp
+++ b/Photino.Native/Photino.Linux.cpp
@@ -52,6 +52,7 @@ gboolean on_webview_context_menu(WebKitWebView *web_view,
 								 gboolean triggered_with_keyboard,
 								 gpointer user_data);
 gboolean on_permission_request(WebKitWebView *web_view, WebKitPermissionRequest *request, gpointer user_data);
+gboolean HandleScriptDialog(WebKitWebView *webView, WebKitScriptDialog *dialog, gpointer arg);
 
 Photino::Photino(PhotinoInitParams *initParams) : _webview(nullptr)
 {
@@ -150,6 +151,7 @@ Photino::Photino(PhotinoInitParams *initParams) : _webview(nullptr)
 	_maximizedCallback = (MaximizedCallback)initParams->MaximizedHandler;
 	_minimizedCallback = (MinimizedCallback)initParams->MinimizedHandler;
 	_restoredCallback = (RestoredCallback)initParams->RestoredHandler;
+	_inputDialogRequestedCallback = (InputDialogRequestedCallback)initParams->InputDialogRequestedHandler;
 	_customSchemeCallback = (WebResourceRequestedCallback)initParams->CustomSchemeHandler;
 
 	// copy strings from the fixed size array passed, but only if they have a value.
@@ -555,6 +557,61 @@ std::string escape_json(const std::string &s)
 	return o.str();
 }
 
+const int InputDialogKindAlert = 0;
+const int InputDialogKindConfirm = 1;
+const int InputDialogKindPrompt = 2;
+const int InputDialogResultHandled = 1;
+const int InputDialogResultDismissed = 2;
+const int InputDialogResultConfirmed = 4;
+const int InputDialogResponseLength = 32768;
+
+gboolean HandleScriptDialog(WebKitWebView *webView, WebKitScriptDialog *dialog, gpointer arg)
+{
+	Photino *photino = (Photino *)arg;
+	if (!photino)
+		return FALSE;
+
+	int kind;
+	AutoString defaultInput = (AutoString)"";
+
+	switch (webkit_script_dialog_get_dialog_type(dialog))
+	{
+		case WEBKIT_SCRIPT_DIALOG_ALERT:
+			kind = InputDialogKindAlert;
+			break;
+		case WEBKIT_SCRIPT_DIALOG_CONFIRM:
+			kind = InputDialogKindConfirm;
+			break;
+		case WEBKIT_SCRIPT_DIALOG_PROMPT:
+			kind = InputDialogKindPrompt;
+			defaultInput = (AutoString)webkit_script_dialog_prompt_get_default_text(dialog);
+			if (!defaultInput)
+				defaultInput = (AutoString)"";
+			break;
+		default:
+			return FALSE;
+	}
+
+	char response[InputDialogResponseLength] = {};
+	AutoString message = (AutoString)webkit_script_dialog_get_message(dialog);
+	int inputResult = photino->InvokeInputDialogRequested(
+		kind,
+		message ? message : (AutoString)"",
+		defaultInput,
+		response,
+		InputDialogResponseLength);
+
+	if (!(inputResult & InputDialogResultHandled))
+		return FALSE;
+
+	if (kind == InputDialogKindConfirm)
+		webkit_script_dialog_confirm_set_confirmed(dialog, !(inputResult & InputDialogResultDismissed) && (inputResult & InputDialogResultConfirmed));
+	else if (kind == InputDialogKindPrompt && !(inputResult & InputDialogResultDismissed))
+		webkit_script_dialog_prompt_set_text(dialog, response);
+
+	return TRUE;
+}
+
 static void webview_eval_finished(GObject *object, GAsyncResult *result, gpointer userdata)
 {
 	InvokeJSWaitInfo *waitInfo = (InvokeJSWaitInfo *)userdata;
@@ -813,6 +870,7 @@ void Photino::Show(bool isAlreadyShown)
 		g_signal_connect(contentManager, "script-message-received::Photinointerop",
 						 G_CALLBACK(HandleWebMessage), (void *)_webMessageReceivedCallback);
 		webkit_user_content_manager_register_script_message_handler(contentManager, "Photinointerop");
+		g_signal_connect(_webview, "script-dialog", G_CALLBACK(HandleScriptDialog), this);
 
 		if (_startUrl != NULL)
 			Photino::NavigateToUrl(_startUrl);

--- a/Photino.Native/Photino.Mac.UiDelegate.mm
+++ b/Photino.Native/Photino.Mac.UiDelegate.mm
@@ -11,7 +11,7 @@ const int InputDialogResponseLength = 32768;
 
 static int InvokeInputDialog(Photino *photino, int kind, NSString *message, NSString *defaultInput, char *response)
 {
-    if (!photino)
+    if (!photino || !photino->GetInputDialogInterceptionEnabled())
         return 0;
 
     response[0] = 0;

--- a/Photino.Native/Photino.Mac.UiDelegate.mm
+++ b/Photino.Native/Photino.Mac.UiDelegate.mm
@@ -1,6 +1,28 @@
 #ifdef __APPLE__
 #import "Photino.Mac.UiDelegate.h"
 
+const int InputDialogKindAlert = 0;
+const int InputDialogKindConfirm = 1;
+const int InputDialogKindPrompt = 2;
+const int InputDialogResultHandled = 1;
+const int InputDialogResultDismissed = 2;
+const int InputDialogResultConfirmed = 4;
+const int InputDialogResponseLength = 32768;
+
+static int InvokeInputDialog(Photino *photino, int kind, NSString *message, NSString *defaultInput, char *response)
+{
+    if (!photino)
+        return 0;
+
+    response[0] = 0;
+    return photino->InvokeInputDialogRequested(
+        kind,
+        (char *)[(message ?: @"") UTF8String],
+        (char *)[(defaultInput ?: @"") UTF8String],
+        response,
+        InputDialogResponseLength);
+}
+
 @implementation UiDelegate : NSObject
 - (void)userContentController:(WKUserContentController *)userContentController
         didReceiveScriptMessage:(WKScriptMessage *)message
@@ -14,6 +36,14 @@
         initiatedByFrame:(WKFrameInfo *)frame
         completionHandler:(void (^)(void))completionHandler
 {
+    char response[InputDialogResponseLength] = {};
+    int inputResult = InvokeInputDialog(photino, InputDialogKindAlert, message, @"", response);
+    if (inputResult & InputDialogResultHandled)
+    {
+        completionHandler();
+        return;
+    }
+
     NSAlert* alert = [[NSAlert alloc] init];
 
     [alert setMessageText: @"Alert"];
@@ -31,6 +61,14 @@
         initiatedByFrame:(WKFrameInfo *)frame
         completionHandler:(void (^)(BOOL result))completionHandler
 {
+    char response[InputDialogResponseLength] = {};
+    int inputResult = InvokeInputDialog(photino, InputDialogKindConfirm, message, @"", response);
+    if (inputResult & InputDialogResultHandled)
+    {
+        completionHandler(!(inputResult & InputDialogResultDismissed) && (inputResult & InputDialogResultConfirmed));
+        return;
+    }
+
     NSAlert* alert = [[NSAlert alloc] init];
 
     [alert setMessageText: @"Confirm"];
@@ -51,6 +89,14 @@
         initiatedByFrame:(WKFrameInfo *)frame
         completionHandler:(void (^)(NSString *result))completionHandler
 {
+    char response[InputDialogResponseLength] = {};
+    int inputResult = InvokeInputDialog(photino, InputDialogKindPrompt, prompt, defaultText, response);
+    if (inputResult & InputDialogResultHandled)
+    {
+        completionHandler(inputResult & InputDialogResultDismissed ? nil : [NSString stringWithUTF8String:response]);
+        return;
+    }
+
     NSAlert* alert = [[NSAlert alloc] init];
 
     [alert setMessageText: @"Prompt"];

--- a/Photino.Native/Photino.Mac.mm
+++ b/Photino.Native/Photino.Mac.mm
@@ -149,6 +149,7 @@ Photino::Photino(PhotinoInitParams* initParams)
     _maximizedCallback = (MaximizedCallback)initParams->MaximizedHandler;
 	_minimizedCallback = (MinimizedCallback)initParams->MinimizedHandler;
 	_restoredCallback = (RestoredCallback)initParams->RestoredHandler;
+	_inputDialogRequestedCallback = (InputDialogRequestedCallback)initParams->InputDialogRequestedHandler;
 	_customSchemeCallback = (WebResourceRequestedCallback)initParams->CustomSchemeHandler;
     
 

--- a/Photino.Native/Photino.Mac.mm
+++ b/Photino.Native/Photino.Mac.mm
@@ -150,6 +150,7 @@ Photino::Photino(PhotinoInitParams* initParams)
 	_minimizedCallback = (MinimizedCallback)initParams->MinimizedHandler;
 	_restoredCallback = (RestoredCallback)initParams->RestoredHandler;
 	_inputDialogRequestedCallback = (InputDialogRequestedCallback)initParams->InputDialogRequestedHandler;
+	_inputDialogInterceptionEnabled = false;
 	_customSchemeCallback = (WebResourceRequestedCallback)initParams->CustomSchemeHandler;
     
 
@@ -607,6 +608,11 @@ void Photino::SetTransparentEnabled(bool enabled)
 void Photino::SetContextMenuEnabled(bool enabled)
 {
     //! Not supported on macOS
+}
+
+void Photino::SetInputDialogInterceptionEnabled(bool enabled)
+{
+    _inputDialogInterceptionEnabled = enabled;
 }
 
 void Photino::SetIconFile(AutoString filename)

--- a/Photino.Native/Photino.Windows.cpp
+++ b/Photino.Native/Photino.Windows.cpp
@@ -45,6 +45,13 @@ struct ShowMessageParams
 	UINT type = 0;
 };
 
+const int InputDialogKindAlert = 0;
+const int InputDialogKindConfirm = 1;
+const int InputDialogKindPrompt = 2;
+const int InputDialogResultHandled = 1;
+const int InputDialogResultDismissed = 2;
+const int InputDialogResultConfirmed = 4;
+const int InputDialogResponseLength = 32768;
 
 const HBRUSH darkBrush = CreateSolidBrush(RGB(0, 0, 0));
 const HBRUSH lightBrush = CreateSolidBrush(RGB(255, 255, 255));
@@ -195,6 +202,7 @@ Photino::Photino(PhotinoInitParams* initParams)
 	_closingCallback = (ClosingCallback)initParams->ClosingHandler;
 	_focusInCallback = (FocusInCallback)initParams->FocusInHandler;
 	_focusOutCallback = (FocusOutCallback)initParams->FocusOutHandler;
+	_inputDialogRequestedCallback = (InputDialogRequestedCallback)initParams->InputDialogRequestedHandler;
 	_customSchemeCallback = (WebResourceRequestedCallback)initParams->CustomSchemeHandler;
 
 	//copy strings from the fixed size array passed, but only if they have a value.
@@ -1043,6 +1051,57 @@ void Photino::AttachWebView()
 								_webMessageReceivedCallback(message.get());
 								return S_OK;
 							}).Get(), &webMessageToken);
+
+						EventRegistrationToken scriptDialogOpeningToken;
+						_webviewWindow->add_ScriptDialogOpening(Callback<ICoreWebView2ScriptDialogOpeningEventHandler>(
+							[&](ICoreWebView2* sender, ICoreWebView2ScriptDialogOpeningEventArgs* args) -> HRESULT {
+								COREWEBVIEW2_SCRIPT_DIALOG_KIND dialogKind;
+								args->get_Kind(&dialogKind);
+
+								int inputDialogKind;
+								switch (dialogKind)
+								{
+									case COREWEBVIEW2_SCRIPT_DIALOG_KIND_ALERT:
+										inputDialogKind = InputDialogKindAlert;
+										break;
+									case COREWEBVIEW2_SCRIPT_DIALOG_KIND_CONFIRM:
+										inputDialogKind = InputDialogKindConfirm;
+										break;
+									case COREWEBVIEW2_SCRIPT_DIALOG_KIND_PROMPT:
+										inputDialogKind = InputDialogKindPrompt;
+										break;
+									default:
+										return S_OK;
+								}
+
+								wil::unique_cotaskmem_string message;
+								args->get_Message(&message);
+
+								wil::unique_cotaskmem_string defaultInput;
+								if (inputDialogKind == InputDialogKindPrompt)
+									args->get_DefaultText(&defaultInput);
+
+								wchar_t response[InputDialogResponseLength] = {};
+								int inputResult = InvokeInputDialogRequested(
+									inputDialogKind,
+									message.get() ? message.get() : L"",
+									defaultInput.get() ? defaultInput.get() : L"",
+									response,
+									InputDialogResponseLength);
+
+								if (!(inputResult & InputDialogResultHandled))
+									return S_OK;
+
+								if (inputDialogKind == InputDialogKindPrompt && !(inputResult & InputDialogResultDismissed))
+									args->put_ResultText(response);
+
+								if (inputDialogKind == InputDialogKindAlert ||
+									(inputDialogKind == InputDialogKindConfirm && !(inputResult & InputDialogResultDismissed) && (inputResult & InputDialogResultConfirmed)) ||
+									(inputDialogKind == InputDialogKindPrompt && !(inputResult & InputDialogResultDismissed)))
+									args->Accept();
+
+								return S_OK;
+							}).Get(), &scriptDialogOpeningToken);
 
 						EventRegistrationToken webResourceRequestedToken;
 						_webviewWindow->AddWebResourceRequestedFilter(L"*", COREWEBVIEW2_WEB_RESOURCE_CONTEXT_ALL);

--- a/Photino.Native/Photino.Windows.cpp
+++ b/Photino.Native/Photino.Windows.cpp
@@ -45,6 +45,15 @@ struct ShowMessageParams
 	UINT type = 0;
 };
 
+struct InputPromptDialogState
+{
+	LPCWSTR message;
+	LPCWSTR defaultInput;
+	std::wstring input;
+	HWND edit;
+	bool accepted;
+};
+
 const int InputDialogKindAlert = 0;
 const int InputDialogKindConfirm = 1;
 const int InputDialogKindPrompt = 2;
@@ -52,9 +61,147 @@ const int InputDialogResultHandled = 1;
 const int InputDialogResultDismissed = 2;
 const int InputDialogResultConfirmed = 4;
 const int InputDialogResponseLength = 32768;
+const int InputPromptDialogWidth = 420;
+const int InputPromptDialogHeight = 170;
+const int InputPromptDialogEdit = 1001;
+const int InputPromptDialogOk = IDOK;
+const int InputPromptDialogCancel = IDCANCEL;
+LPCWSTR InputPromptDialogClassName = L"PhotinoInputPromptDialog";
 
 const HBRUSH darkBrush = CreateSolidBrush(RGB(0, 0, 0));
 const HBRUSH lightBrush = CreateSolidBrush(RGB(255, 255, 255));
+
+LRESULT CALLBACK InputPromptDialogProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
+{
+	auto state = reinterpret_cast<InputPromptDialogState*>(GetWindowLongPtr(hwnd, GWLP_USERDATA));
+
+	switch (uMsg)
+	{
+		case WM_NCCREATE:
+		{
+			auto createStruct = reinterpret_cast<CREATESTRUCT*>(lParam);
+			SetWindowLongPtr(hwnd, GWLP_USERDATA, reinterpret_cast<LONG_PTR>(createStruct->lpCreateParams));
+			return TRUE;
+		}
+		case WM_CREATE:
+		{
+			state = reinterpret_cast<InputPromptDialogState*>(GetWindowLongPtr(hwnd, GWLP_USERDATA));
+			HFONT font = static_cast<HFONT>(GetStockObject(DEFAULT_GUI_FONT));
+
+			HWND label = CreateWindowExW(0, L"STATIC", state->message, WS_CHILD | WS_VISIBLE | SS_LEFT, 16, 16, 372, 38, hwnd, nullptr, nullptr, nullptr);
+			SendMessage(label, WM_SETFONT, reinterpret_cast<WPARAM>(font), TRUE);
+
+			state->edit = CreateWindowExW(WS_EX_CLIENTEDGE, L"EDIT", state->defaultInput, WS_CHILD | WS_VISIBLE | WS_TABSTOP | ES_AUTOHSCROLL, 16, 62, 372, 24, hwnd, reinterpret_cast<HMENU>(static_cast<INT_PTR>(InputPromptDialogEdit)), nullptr, nullptr);
+			SendMessage(state->edit, WM_SETFONT, reinterpret_cast<WPARAM>(font), TRUE);
+
+			HWND okButton = CreateWindowExW(0, L"BUTTON", L"OK", WS_CHILD | WS_VISIBLE | WS_TABSTOP | BS_DEFPUSHBUTTON, 224, 104, 78, 26, hwnd, reinterpret_cast<HMENU>(static_cast<INT_PTR>(InputPromptDialogOk)), nullptr, nullptr);
+			SendMessage(okButton, WM_SETFONT, reinterpret_cast<WPARAM>(font), TRUE);
+
+			HWND cancelButton = CreateWindowExW(0, L"BUTTON", L"Cancel", WS_CHILD | WS_VISIBLE | WS_TABSTOP, 310, 104, 78, 26, hwnd, reinterpret_cast<HMENU>(static_cast<INT_PTR>(InputPromptDialogCancel)), nullptr, nullptr);
+			SendMessage(cancelButton, WM_SETFONT, reinterpret_cast<WPARAM>(font), TRUE);
+
+			SetFocus(state->edit);
+			SendMessage(state->edit, EM_SETSEL, 0, -1);
+			return FALSE;
+		}
+		case WM_COMMAND:
+		{
+			switch (LOWORD(wParam))
+			{
+				case InputPromptDialogOk:
+				{
+					int length = GetWindowTextLengthW(state->edit);
+					std::vector<wchar_t> buffer(length + 1);
+					GetWindowTextW(state->edit, buffer.data(), static_cast<int>(buffer.size()));
+					state->input = buffer.data();
+					state->accepted = true;
+					DestroyWindow(hwnd);
+					return 0;
+				}
+				case InputPromptDialogCancel:
+					DestroyWindow(hwnd);
+					return 0;
+			}
+			break;
+		}
+		case WM_CLOSE:
+			DestroyWindow(hwnd);
+			return 0;
+	}
+
+	return DefWindowProc(hwnd, uMsg, wParam, lParam);
+}
+
+bool ShowInputPromptDialog(HWND owner, LPCWSTR message, LPCWSTR defaultInput, std::wstring* input)
+{
+	WNDCLASSEX wcx = {};
+	wcx.cbSize = sizeof WNDCLASSEX;
+	wcx.lpfnWndProc = InputPromptDialogProc;
+	wcx.hInstance = GetModuleHandle(nullptr);
+	wcx.hCursor = LoadCursor(nullptr, IDC_ARROW);
+	wcx.hbrBackground = reinterpret_cast<HBRUSH>(COLOR_WINDOW + 1);
+	wcx.lpszClassName = InputPromptDialogClassName;
+	RegisterClassEx(&wcx);
+
+	RECT ownerRect;
+	if (owner && GetWindowRect(owner, &ownerRect))
+	{
+		int x = ownerRect.left + ((ownerRect.right - ownerRect.left) - InputPromptDialogWidth) / 2;
+		int y = ownerRect.top + ((ownerRect.bottom - ownerRect.top) - InputPromptDialogHeight) / 2;
+		ownerRect = { x, y, x + InputPromptDialogWidth, y + InputPromptDialogHeight };
+	}
+	else
+	{
+		int x = (GetSystemMetrics(SM_CXSCREEN) - InputPromptDialogWidth) / 2;
+		int y = (GetSystemMetrics(SM_CYSCREEN) - InputPromptDialogHeight) / 2;
+		ownerRect = { x, y, x + InputPromptDialogWidth, y + InputPromptDialogHeight };
+	}
+
+	InputPromptDialogState state = { message, defaultInput, L"", nullptr, false };
+	HWND hwnd = CreateWindowExW(
+		WS_EX_DLGMODALFRAME,
+		InputPromptDialogClassName,
+		L"Prompt",
+		WS_CAPTION | WS_SYSMENU | WS_POPUP,
+		ownerRect.left,
+		ownerRect.top,
+		InputPromptDialogWidth,
+		InputPromptDialogHeight,
+		owner,
+		nullptr,
+		GetModuleHandle(nullptr),
+		&state);
+
+	if (!hwnd)
+		return false;
+
+	if (owner)
+		EnableWindow(owner, FALSE);
+
+	ShowWindow(hwnd, SW_SHOW);
+	UpdateWindow(hwnd);
+
+	MSG msg;
+	while (IsWindow(hwnd) && GetMessage(&msg, nullptr, 0, 0) > 0)
+	{
+		if (!IsDialogMessage(hwnd, &msg))
+		{
+			TranslateMessage(&msg);
+			DispatchMessage(&msg);
+		}
+	}
+
+	if (owner)
+	{
+		EnableWindow(owner, TRUE);
+		SetActiveWindow(owner);
+	}
+
+	if (state.accepted)
+		*input = state.input;
+
+	return state.accepted;
+}
 
 void Photino::Register(HINSTANCE hInstance)
 {
@@ -1003,19 +1150,13 @@ void Photino::UpdateScriptDialogOpeningHandler()
 	if (!_inputDialogInterceptionEnabled)
 	{
 		Settings->put_AreDefaultScriptDialogsEnabled(TRUE);
-		if (_scriptDialogOpeningRegistered)
-		{
-			_webviewWindow->remove_ScriptDialogOpening(_scriptDialogOpeningToken);
-			_scriptDialogOpeningRegistered = false;
-			_scriptDialogOpeningToken = {};
-		}
 		return;
 	}
 
+	Settings->put_AreDefaultScriptDialogsEnabled(FALSE);
 	if (_scriptDialogOpeningRegistered)
 		return;
 
-	Settings->put_AreDefaultScriptDialogsEnabled(FALSE);
 	_webviewWindow->add_ScriptDialogOpening(Callback<ICoreWebView2ScriptDialogOpeningEventHandler>(
 		[&](ICoreWebView2* sender, ICoreWebView2ScriptDialogOpeningEventArgs* args) -> HRESULT {
 			COREWEBVIEW2_SCRIPT_DIALOG_KIND dialogKind;
@@ -1053,7 +1194,28 @@ void Photino::UpdateScriptDialogOpeningHandler()
 				InputDialogResponseLength);
 
 			if (!(inputResult & InputDialogResultHandled))
+			{
+				if (inputDialogKind == InputDialogKindAlert)
+				{
+					MessageBoxW(_hWnd, message.get() ? message.get() : L"", L"Alert", MB_OK);
+					args->Accept();
+				}
+				else if (inputDialogKind == InputDialogKindConfirm)
+				{
+					if (MessageBoxW(_hWnd, message.get() ? message.get() : L"", L"Confirm", MB_OKCANCEL) == IDOK)
+						args->Accept();
+				}
+				else if (inputDialogKind == InputDialogKindPrompt)
+				{
+					std::wstring promptResult;
+					if (ShowInputPromptDialog(_hWnd, message.get() ? message.get() : L"", defaultInput.get() ? defaultInput.get() : L"", &promptResult))
+					{
+						args->put_ResultText(promptResult.c_str());
+						args->Accept();
+					}
+				}
 				return S_OK;
+			}
 
 			if (inputDialogKind == InputDialogKindPrompt && !(inputResult & InputDialogResultDismissed))
 				args->put_ResultText(response);

--- a/Photino.Native/Photino.Windows.cpp
+++ b/Photino.Native/Photino.Windows.cpp
@@ -203,6 +203,8 @@ Photino::Photino(PhotinoInitParams* initParams)
 	_focusInCallback = (FocusInCallback)initParams->FocusInHandler;
 	_focusOutCallback = (FocusOutCallback)initParams->FocusOutHandler;
 	_inputDialogRequestedCallback = (InputDialogRequestedCallback)initParams->InputDialogRequestedHandler;
+	_inputDialogInterceptionEnabled = false;
+	_scriptDialogOpeningRegistered = false;
 	_customSchemeCallback = (WebResourceRequestedCallback)initParams->CustomSchemeHandler;
 
 	//copy strings from the fixed size array passed, but only if they have a value.
@@ -735,6 +737,12 @@ void Photino::SetDevToolsEnabled(bool enabled)
 	_webviewWindow->Reload();
 }
 
+void Photino::SetInputDialogInterceptionEnabled(bool enabled)
+{
+	_inputDialogInterceptionEnabled = enabled;
+	UpdateScriptDialogOpeningHandler();
+}
+
 void Photino::SetFullScreen(bool fullScreen)
 {
 	LONG_PTR style = GetWindowLongPtr(_hWnd, GWL_STYLE);
@@ -984,6 +992,82 @@ AutoString Photino::ToUTF16String(AutoString source)
 	return response;
 }
 
+void Photino::UpdateScriptDialogOpeningHandler()
+{
+	if (!_webviewWindow)
+		return;
+
+	wil::com_ptr<ICoreWebView2Settings> Settings;
+	_webviewWindow->get_Settings(Settings.put());
+
+	if (!_inputDialogInterceptionEnabled)
+	{
+		Settings->put_AreDefaultScriptDialogsEnabled(TRUE);
+		if (_scriptDialogOpeningRegistered)
+		{
+			_webviewWindow->remove_ScriptDialogOpening(_scriptDialogOpeningToken);
+			_scriptDialogOpeningRegistered = false;
+			_scriptDialogOpeningToken = {};
+		}
+		return;
+	}
+
+	if (_scriptDialogOpeningRegistered)
+		return;
+
+	Settings->put_AreDefaultScriptDialogsEnabled(FALSE);
+	_webviewWindow->add_ScriptDialogOpening(Callback<ICoreWebView2ScriptDialogOpeningEventHandler>(
+		[&](ICoreWebView2* sender, ICoreWebView2ScriptDialogOpeningEventArgs* args) -> HRESULT {
+			COREWEBVIEW2_SCRIPT_DIALOG_KIND dialogKind;
+			args->get_Kind(&dialogKind);
+
+			int inputDialogKind;
+			switch (dialogKind)
+			{
+				case COREWEBVIEW2_SCRIPT_DIALOG_KIND_ALERT:
+					inputDialogKind = InputDialogKindAlert;
+					break;
+				case COREWEBVIEW2_SCRIPT_DIALOG_KIND_CONFIRM:
+					inputDialogKind = InputDialogKindConfirm;
+					break;
+				case COREWEBVIEW2_SCRIPT_DIALOG_KIND_PROMPT:
+					inputDialogKind = InputDialogKindPrompt;
+					break;
+				default:
+					return S_OK;
+			}
+
+			wil::unique_cotaskmem_string message;
+			args->get_Message(&message);
+
+			wil::unique_cotaskmem_string defaultInput;
+			if (inputDialogKind == InputDialogKindPrompt)
+				args->get_DefaultText(&defaultInput);
+
+			wchar_t response[InputDialogResponseLength] = {};
+			int inputResult = InvokeInputDialogRequested(
+				inputDialogKind,
+				message.get() ? message.get() : L"",
+				defaultInput.get() ? defaultInput.get() : L"",
+				response,
+				InputDialogResponseLength);
+
+			if (!(inputResult & InputDialogResultHandled))
+				return S_OK;
+
+			if (inputDialogKind == InputDialogKindPrompt && !(inputResult & InputDialogResultDismissed))
+				args->put_ResultText(response);
+
+			if (inputDialogKind == InputDialogKindAlert ||
+				(inputDialogKind == InputDialogKindConfirm && !(inputResult & InputDialogResultDismissed) && (inputResult & InputDialogResultConfirmed)) ||
+				(inputDialogKind == InputDialogKindPrompt && !(inputResult & InputDialogResultDismissed)))
+				args->Accept();
+
+			return S_OK;
+		}).Get(), &_scriptDialogOpeningToken);
+	_scriptDialogOpeningRegistered = true;
+}
+
 void Photino::AttachWebView()
 {
 	size_t runtimePathLen = wcsnlen(_webview2RuntimePath, _countof(_webview2RuntimePath));
@@ -1052,56 +1136,7 @@ void Photino::AttachWebView()
 								return S_OK;
 							}).Get(), &webMessageToken);
 
-						EventRegistrationToken scriptDialogOpeningToken;
-						_webviewWindow->add_ScriptDialogOpening(Callback<ICoreWebView2ScriptDialogOpeningEventHandler>(
-							[&](ICoreWebView2* sender, ICoreWebView2ScriptDialogOpeningEventArgs* args) -> HRESULT {
-								COREWEBVIEW2_SCRIPT_DIALOG_KIND dialogKind;
-								args->get_Kind(&dialogKind);
-
-								int inputDialogKind;
-								switch (dialogKind)
-								{
-									case COREWEBVIEW2_SCRIPT_DIALOG_KIND_ALERT:
-										inputDialogKind = InputDialogKindAlert;
-										break;
-									case COREWEBVIEW2_SCRIPT_DIALOG_KIND_CONFIRM:
-										inputDialogKind = InputDialogKindConfirm;
-										break;
-									case COREWEBVIEW2_SCRIPT_DIALOG_KIND_PROMPT:
-										inputDialogKind = InputDialogKindPrompt;
-										break;
-									default:
-										return S_OK;
-								}
-
-								wil::unique_cotaskmem_string message;
-								args->get_Message(&message);
-
-								wil::unique_cotaskmem_string defaultInput;
-								if (inputDialogKind == InputDialogKindPrompt)
-									args->get_DefaultText(&defaultInput);
-
-								wchar_t response[InputDialogResponseLength] = {};
-								int inputResult = InvokeInputDialogRequested(
-									inputDialogKind,
-									message.get() ? message.get() : L"",
-									defaultInput.get() ? defaultInput.get() : L"",
-									response,
-									InputDialogResponseLength);
-
-								if (!(inputResult & InputDialogResultHandled))
-									return S_OK;
-
-								if (inputDialogKind == InputDialogKindPrompt && !(inputResult & InputDialogResultDismissed))
-									args->put_ResultText(response);
-
-								if (inputDialogKind == InputDialogKindAlert ||
-									(inputDialogKind == InputDialogKindConfirm && !(inputResult & InputDialogResultDismissed) && (inputResult & InputDialogResultConfirmed)) ||
-									(inputDialogKind == InputDialogKindPrompt && !(inputResult & InputDialogResultDismissed)))
-									args->Accept();
-
-								return S_OK;
-							}).Get(), &scriptDialogOpeningToken);
+						UpdateScriptDialogOpeningHandler();
 
 						EventRegistrationToken webResourceRequestedToken;
 						_webviewWindow->AddWebResourceRequestedFilter(L"*", COREWEBVIEW2_WEB_RESOURCE_CONTEXT_ALL);

--- a/Photino.Native/Photino.h
+++ b/Photino.Native/Photino.h
@@ -52,6 +52,7 @@ typedef void (*MovedCallback)(int x, int y);
 typedef bool (*ClosingCallback)();
 typedef void (*FocusInCallback)();
 typedef void (*FocusOutCallback)();
+typedef int (*InputDialogRequestedCallback)(int kind, AutoString message, AutoString defaultInput, AutoString response, int responseLength);
 
 class PhotinoDialog;
 class Photino;
@@ -78,6 +79,7 @@ struct PhotinoInitParams
 	MinimizedCallback *MinimizedHandler;
 	MovedCallback *MovedHandler;
 	WebMessageReceivedCallback *WebMessageReceivedHandler;
+	InputDialogRequestedCallback *InputDialogRequestedHandler;
 	AutoString CustomSchemeNames[16];
 	WebResourceRequestedCallback *CustomSchemeHandler;
 
@@ -128,6 +130,7 @@ private:
 	ClosingCallback _closingCallback;
 	FocusInCallback _focusInCallback;
 	FocusOutCallback _focusOutCallback;
+	InputDialogRequestedCallback _inputDialogRequestedCallback;
 	std::vector<AutoString> _customSchemeNames;
 	WebResourceRequestedCallback _customSchemeCallback;
 
@@ -272,6 +275,10 @@ public:
 
 	void NavigateToString(AutoString content);
 	void NavigateToUrl(AutoString url);
+	int InvokeInputDialogRequested(int kind, AutoString message, AutoString defaultInput, AutoString response, int responseLength)
+	{
+		return _inputDialogRequestedCallback ? _inputDialogRequestedCallback(kind, message, defaultInput, response, responseLength) : 0;
+	}
 	void Restore(); // required anymore?backward compat?
 	void SendWebMessage(AutoString message);
 

--- a/Photino.Native/Photino.h
+++ b/Photino.Native/Photino.h
@@ -131,6 +131,7 @@ private:
 	FocusInCallback _focusInCallback;
 	FocusOutCallback _focusOutCallback;
 	InputDialogRequestedCallback _inputDialogRequestedCallback;
+	bool _inputDialogInterceptionEnabled;
 	std::vector<AutoString> _customSchemeNames;
 	WebResourceRequestedCallback _customSchemeCallback;
 
@@ -167,9 +168,12 @@ private:
 	wil::com_ptr<ICoreWebView2Environment> _webviewEnvironment;
 	wil::com_ptr<ICoreWebView2> _webviewWindow;
 	wil::com_ptr<ICoreWebView2Controller> _webviewController;
+	EventRegistrationToken _scriptDialogOpeningToken = {};
+	bool _scriptDialogOpeningRegistered;
 	bool EnsureWebViewIsInstalled();
 	bool InstallWebView2();
 	void AttachWebView();
+	void UpdateScriptDialogOpeningHandler();
 	bool ToWide(PhotinoInitParams* params);
 	
 #elif __linux__
@@ -272,6 +276,7 @@ public:
 	void GetTopmost(bool *topmost);
 	void GetZoom(int *zoom);
 	void GetIgnoreCertificateErrorsEnabled(bool* enabled);
+	bool GetInputDialogInterceptionEnabled() { return _inputDialogInterceptionEnabled; }
 
 	void NavigateToString(AutoString content);
 	void NavigateToUrl(AutoString url);
@@ -285,6 +290,7 @@ public:
 	void SetTransparentEnabled(bool enabled);
 	void SetContextMenuEnabled(bool enabled);
 	void SetDevToolsEnabled(bool enabled);
+	void SetInputDialogInterceptionEnabled(bool enabled);
 	void SetIconFile(AutoString filename);
 	void SetFullScreen(bool fullScreen);
 	void SetMaximized(bool maximized);

--- a/Photino.Test/Photino.Test.csproj
+++ b/Photino.Test/Photino.Test.csproj
@@ -31,6 +31,7 @@
   <ItemGroup>
     <Compile Include="..\..\photino.NET\Photino.NET\PhotinoDialogEnums.cs" Link="PhotinoDialogEnums.cs" />
     <Compile Include="..\..\photino.NET\Photino.NET\PhotinoDllImports.cs" Link="PhotinoDllImports.cs" />
+    <Compile Include="..\..\photino.NET\Photino.NET\InputDialogEventArgs.cs" Link="InputDialogEventArgs.cs" />
     <Compile Include="..\..\photino.NET\Photino.NET\PhotinoMonitorStruct.cs" Link="PhotinoMonitorStruct.cs" />
     <Compile Include="..\..\photino.NET\Photino.NET\PhotinoNativeDelegates.cs" Link="PhotinoNativeDelegates.cs" />
     <Compile Include="..\..\photino.NET\Photino.NET\PhotinoNativeParameters.cs" Link="PhotinoNativeParameters.cs" />


### PR DESCRIPTION
## Summary
- Wires JavaScript alert/confirm/prompt interception to the new InputDialogRequested callback
- Adds WebView2 ScriptDialogOpening handling on Windows
- Adds WKUIDelegate handling on macOS and WebKitGTK script-dialog handling on Linux
- Links InputDialogEventArgs in Photino.Test

## Related
- Companion .NET API PR: tryphotino/photino.NET#277

## Validation
- dotnet build Photino.NET.sln --no-restore from photino.NET
- dotnet build Photino.Test\\Photino.Test.csproj --no-restore

## Notes
- Native C++ build was not completed locally because the installed MSBuild cannot find the required v143 platform toolset.