### PR TITLE
Fix heap over-read: StartString/StartUrl are UTF-8 but the Windows ctor uses wcslen/wcscpy

### DIFF
--- a/Photino.Native/Photino.Windows.cpp
+++ b/Photino.Native/Photino.Windows.cpp
@@ -111,22 +111,26 @@ Photino::Photino(PhotinoInitParams* initParams)
 	_startUrl = NULL;
 	if (initParams->StartUrl != NULL)
 	{
-		_startUrl = new wchar_t[2048];
+		// StartUrl arrives as a UTF-8 byte buffer (the managed side marshals it as LPUTF8Str) and is
+		// converted to UTF-16 later in NavigateToUrl (via ToUTF16String). Keep the bytes as-is here and
+		// duplicate them with NARROW routines. wcslen/wcscpy would scan/copy 16 bits at a time looking
+		// for a wide 0x0000, walking past the single trailing 0x00 of the UTF-8 buffer -> heap over-read
+		// (intermittent STATUS_HEAP_CORRUPTION). The fixed 2048 cap is also gone (sized to the content).
+		size_t startUrlLen = strlen((char*)initParams->StartUrl);
+		_startUrl = (AutoString)new char[startUrlLen + 1];
 		if (_startUrl == NULL) exit(0);
-		//AutoString wStartUrl = ToUTF16String(initParams->StartUrl);	//Conversion is done in Navigate method. Don't do it twice
-		//wcscpy(_startUrl, wStartUrl);
-		wcscpy(_startUrl, initParams->StartUrl);
+		strcpy((char*)_startUrl, (char*)initParams->StartUrl);
 	}
 
 	_startString = NULL;
 	if (initParams->StartString != NULL)
 	{
-		//AutoString wStartString = ToUTF16String(initParams->StartString);	//Conversion is done in Navigate method. Don't do it twice
-		//_startString = new wchar_t[wcslen(wStartString) + 1];
-		_startString = new wchar_t[wcslen(initParams->StartString) + 1];
+		// StartString is also a UTF-8 byte buffer; NavigateToString converts it later. Same reason as
+		// StartUrl: measure/copy with strlen/strcpy, never wcslen/wcscpy over a UTF-8 buffer.
+		size_t startStringLen = strlen((char*)initParams->StartString);
+		_startString = (AutoString)new char[startStringLen + 1];
 		if (_startString == NULL) exit(0);
-		//wcscpy(_startString, wStartString);
-		wcscpy(_startString, initParams->StartString);
+		strcpy((char*)_startString, (char*)initParams->StartString);
 	}
 
 	_temporaryFilesPath = NULL;
@@ -313,8 +317,8 @@ Photino::Photino(PhotinoInitParams* initParams)
 
 Photino::~Photino()
 {
-	if (_startUrl != NULL) delete[]_startUrl;
-	if (_startString != NULL) delete[]_startString;
+	if (_startUrl != NULL) delete[](char*)_startUrl;		// allocated as char[] (UTF-8); free as char[]
+	if (_startString != NULL) delete[](char*)_startString;
 	if (_temporaryFilesPath != NULL) delete[]_temporaryFilesPath;
 	if (_windowTitle != NULL) delete[]_windowTitle;
 	if (_notificationsEnabled && _toastHandler != NULL) delete _toastHandler;


### PR DESCRIPTION
# Fix heap over-read: `StartString`/`StartUrl` are UTF-8 but the Windows ctor uses `wcslen`/`wcscpy`

## Summary

On Windows, `Photino::Photino(PhotinoInitParams*)` duplicates `StartUrl` and `StartString` with the
**wide** routines `wcslen`/`wcscpy`, but those buffers are **UTF-8** (the managed side marshals them as
`LPUTF8Str`). Reading a UTF-8 buffer with wide-char functions scans past its single trailing `0x00`
terminator, causing a **heap over-read** — intermittent `STATUS_HEAP_CORRUPTION` (`0xC0000374`) on any app
that uses `LoadRawString(...)` (`StartString`) or `Load(url)` (`StartUrl`).

This matches the user-visible "blank window / dies on init" reports (e.g. tryphotino/photino.NET#274 on
Win10 19045).

## Root cause

`Photino.NET/PhotinoNativeParameters.cs` marshals both fields as UTF-8:

```csharp
[MarshalAs(UnmanagedType.LPUTF8Str)] internal string StartString;   // UTF-8 char*, single-byte NUL
[MarshalAs(UnmanagedType.LPUTF8Str)] internal string StartUrl;
```

Every *other* string param in the Windows ctor is converted UTF-8 → UTF-16 via `ToUTF16String(...)`
before use. `StartUrl`/`StartString` deliberately skip that (they're converted later, in
`NavigateToUrl`/`NavigateToString`) — **but the ctor still measures and copies them with `wcslen`/`wcscpy`:**

```cpp
_startUrl = new wchar_t[2048];
wcscpy(_startUrl, initParams->StartUrl);                       // wcscpy over a UTF-8 buffer

_startString = new wchar_t[wcslen(initParams->StartString) + 1];
wcscpy(_startString, initParams->StartString);                 // wcslen/wcscpy over a UTF-8 buffer
```

`wcslen` scans **16 bits at a time** for a `0x0000` pair. The UTF-8 buffer ends in a lone `0x00` byte
followed by whatever happens to be on the heap, so the scan walks past the end of the allocation until it
chances upon two `0x00` bytes on a 2-byte boundary — an out-of-bounds read (and `wcscpy` then an OOB
read+write). Whether it corrupts heap metadata depends on adjacent bytes, which is why it's intermittent
(~1 in 7 launches in practice). The original `new wchar_t[2048]` on `StartUrl` is also a fixed cap that
would overflow for URLs longer than 2048.

This is consistent with the existing developer comments ("Conversion is done in Navigate method. Don't do
it twice") — the intent is to keep the buffers UTF-8 and convert later. The defect is only the
wide-char *measure/copy* in the ctor.

## Fix

Keep the buffers UTF-8 and duplicate them with **narrow** routines (`strlen`/`strcpy`), matching what the
macOS and Linux constructors already do for these same members. `NavigateToString`/`NavigateToUrl` already
call `ToUTF16String(...)`, whose Windows implementation treats its input as a UTF-8 `char*`
(`strlen` + `MultiByteToWideChar(CP_UTF8, ...)`), so the contract is preserved.

Note: on Windows `AutoString` is `typedef wchar_t*`, so the duplicated `char[]` is stored through that
type with a cast (and freed as `char[]` in the dtor). The member type is unchanged, so the later
`NavigateToString(_startString)` / `NavigateToUrl(_startUrl)` calls compile and behave exactly as before —
they just receive valid, fully-copied UTF-8 bytes instead of a wcscpy'd buffer. The fixed 2048-byte cap on
`StartUrl` is removed (sized to the content).

## Verification

Built `Photino.Native.dll` (x64) with the change and exercised it with a .NET 8 app that calls
`LoadRawString(html)`, under **Full Page Heap** (`PageHeapFlags=0x3`) on the app, which makes the over-read
fault deterministically against a guard page:

| Build | Result (10 launches, Full Page Heap) |
|---|---|
| before (current `master`) | **10/10 crash** — `0xC0000005` access violation in `Photino::Photino`, ~1.2–1.9 s in, during window construction |
| after (this change) | **10/10 succeed** — window constructs and renders, 0 faults |

Without page heap, the same app reproduces the original intermittent `0xC0000374` and is stable after the
fix.

## Files changed

- `Photino.Native/Photino.Windows.cpp` — `Photino::Photino` ctor (`StartUrl`/`StartString` duplication) and
  the matching `delete[]` in `~Photino`.
